### PR TITLE
add cache to  fix #116 performace issue 

### DIFF
--- a/packages/x6/src/dom/util/style.ts
+++ b/packages/x6/src/dom/util/style.ts
@@ -28,11 +28,29 @@ export function getComputedStyle(elem: Element, name?: string) {
   return computed
 }
 
-export function hasScrollbars(container: HTMLElement) {
+interface Container extends HTMLElement {
+  cacheTime?: number
+  hasScrollbars?: boolean
+}
+
+export function hasScrollbars(
+  container: Container,
+  cache: boolean = true,
+): boolean {
+  const now = Date.now()
+  if (cache) {
+    const { hasScrollbars, cacheTime = 0 } = container
+    const queryGap = Date.now() - cacheTime
+    if ((hasScrollbars === false || hasScrollbars === true) && queryGap < 500) {
+      return hasScrollbars
+    }
+  }
   const style = getComputedStyle(container)
-  return (
+  const hasScrollbars =
     style != null && (style.overflow === 'scroll' || style.overflow === 'auto')
-  )
+  container.cacheTime = now
+  container.hasScrollbars = hasScrollbars
+  return hasScrollbars
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

add cache to Close #116

<!--- Describe your changes in detail -->

### Motivation and Context
add timestamp  and  hasScrollbars bool value to dom container to avoid browser  dom layout  reflo in 500ms threshold. 

500ms 内只查询一次dom  来判断hasScrollbars

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.