### PR TITLE
Fix: typo "getPovider" in "portal" of x6-react-shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+.idea
 npm-debug.log
 yarn-error.log
 lerna-debug.log

--- a/examples/x6-example-features/src/pages/react/portal.tsx
+++ b/examples/x6-example-features/src/pages/react/portal.tsx
@@ -87,7 +87,7 @@ export default class Example extends React.Component {
   }
 
   render() {
-    const X6ReactPortalProvider = Portal.getPovider()
+    const X6ReactPortalProvider = Portal.getProvider()
     return (
       <div className="x6-graph-wrap">
         <X6ReactPortalProvider />

--- a/packages/x6-react-shape/src/portal.ts
+++ b/packages/x6-react-shape/src/portal.ts
@@ -53,7 +53,7 @@ export namespace Portal {
     return active
   }
 
-  export function getPovider() {
+  export function getProvider() {
     return () => {
       active = true
       const [items, mutate] = useReducer(reducer, [])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Typo `getPovider` in `x6-react-shape` Portal API.

<!--- Describe your changes in detail -->

* fix: in the `packages/x6-react-shape/src/portal.ts`, API name `getPovider` should be `getProvider`.
* chore: add `.idea` to `.gitignore` for jetbrains IDE

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.