### PR TITLE
fix: add trigger point for update in scroller

### DIFF
--- a/packages/x6/src/addon/scroller/index.ts
+++ b/packages/x6/src/addon/scroller/index.ts
@@ -1,8 +1,10 @@
 import { Point, Rectangle } from '../../geometry'
 import { Platform, NumberExt, ObjectExt, Dom, FunctionExt } from '../../util'
+import { Model } from '../../model/model'
 import { Cell } from '../../model/cell'
 import { View } from '../../view/view'
 import { Graph } from '../../graph'
+import { Renderer } from '../../graph/renderer'
 import { GraphView } from '../../graph/view'
 import { EventArgs } from '../../graph/events'
 import { TransformManager } from '../../graph/transform'
@@ -122,6 +124,7 @@ export class Scroller extends View {
         model.on('cell:added', this.update, this)
         model.on('cell:removed', this.update, this)
         model.on('cell:changed', this.update, this)
+        model.on('batch:stop', this.onBatchStop, this)
       }
     }
     this.delegateBackgroundEvents()
@@ -145,6 +148,7 @@ export class Scroller extends View {
     model.off('cell:added', this.update, this)
     model.off('cell:removed', this.update, this)
     model.off('cell:changed', this.update, this)
+    model.off('batch:stop', this.onBatchStop, this)
     this.undelegateBackgroundEvents()
   }
 
@@ -296,6 +300,12 @@ export class Scroller extends View {
             .appendTo(this.pageBreak)
         }
       }
+    }
+  }
+
+  onBatchStop(args: { name: Model.BatchName }) {
+    if (Renderer.UPDATE_DELAYING_BATCHES.includes(args.name)) {
+      this.update()
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

batch:stop 事件之后也触发一次update，解决移动节点后计算 contentarea 使用的是之前的 area

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.