### PR TITLE
fix: 🐛 fast switch menubar-item lead to multiple popup

### DIFF
--- a/packages/x6-react-components/src/menubar/item.tsx
+++ b/packages/x6-react-components/src/menubar/item.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames'
 import addEventListener from 'rc-util/lib/Dom/addEventListener'
 import { MenubarContext } from './context'
 
+const cacheDeactiveMap = new WeakMap()
 class MenubarItemInner extends React.PureComponent<
   MenubarItemInner.Props,
   MenubarItemInner.State
@@ -70,11 +71,7 @@ class MenubarItemInner extends React.PureComponent<
     const relatedTarget = e.relatedTarget
     const currentTarget = e.currentTarget as HTMLDivElement
 
-    if (
-      this.props.context.menubarActived &&
-      this.state.active &&
-      !this.isPrevMenuHiddening(e)
-    ) {
+    if (this.props.context.menubarActived && this.state.active) {
       const childNodes = currentTarget.parentElement!.childNodes
       let shoudDeactive = false
       if (relatedTarget !== window) {
@@ -100,18 +97,18 @@ class MenubarItemInner extends React.PureComponent<
   }
 
   cacheDeactive(elem: any) {
-    elem.DEACTIVE = this.deactive
+    cacheDeactiveMap.set(elem, this.deactive)
   }
 
   callDeactive(elem: any) {
-    if (elem.DEACTIVE) {
-      elem.DEACTIVE()
-      delete elem.DEACTIVE
+    if (cacheDeactiveMap.has(elem)) {
+      cacheDeactiveMap.get(elem)()
+      cacheDeactiveMap.delete(elem)
     }
   }
 
   removeDeactive(elem: any) {
-    delete elem.DEACTIVE
+    cacheDeactiveMap.delete(elem)
   }
 
   active = () => {


### PR DESCRIPTION
问题： 快速切换item 会出现重复的 弹框
原因：isPrevMenuHiddening 函数为true 即上个菜单正在关闭时候 onMouseLeave 不会向 dom 写入deactive 关闭 弹出框函数     onMouseEnter 时候 执行销毁其它弹出框时候就会 调用不到
改动方案：onMouseLeave 去除 isPrevMenuHiddening 校验
优化： 销毁弹框事件不挂在dom 上面  减少dom上面事件 节省内存