### PR TITLE
ci(fix): 👷 🐛 use pull_request_target event hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - next-major
       - alpha
       - beta
-  pull_request:
+  pull_request_target:
 
 jobs:
   ci:


### PR DESCRIPTION
fix secrets not accessable

fix #424
