### PR TITLE
fix: 🐛 get completed picture when execue toPNG

### DIFF
--- a/examples/x6-example-features/src/pages/scroller/index.tsx
+++ b/examples/x6-example-features/src/pages/scroller/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from 'antd'
-import { Graph, NodeView } from '@antv/x6'
+import { Graph, NodeView, DataUri } from '@antv/x6'
 import '../index.less'
 import './index.less'
 
@@ -162,6 +162,12 @@ export default class Example extends React.Component {
     this.scroller.zoomToFit()
   }
 
+  onDownload = () => {
+    this.graph.toPNG((datauri: string) => {
+      DataUri.downloadDataUri(datauri, 'chart.png')
+    })
+  }
+
   render() {
     return (
       <div className="x6-graph-wrap">
@@ -172,6 +178,7 @@ export default class Example extends React.Component {
           <Button onClick={this.onZoomOutClick}>Zoom Out</Button>
           <Button onClick={this.onZoomInClick}>Zoom In</Button>
           <Button onClick={this.onZoomToFitClick}>Zoom To Fit</Button>
+          <Button onClick={this.onDownload}>Download</Button>
         </div>
         <div
           ref={this.refMinimap}

--- a/packages/x6/src/graph/format.ts
+++ b/packages/x6/src/graph/format.ts
@@ -182,8 +182,7 @@ export class FormatManager extends Base {
     callback: FormatManager.ToSVGCallback,
     options: FormatManager.ToDataURLOptions,
   ) {
-    let viewBox =
-      options.viewBox || this.graph.graphToLocal(this.graph.getContentBBox())
+    let viewBox = options.viewBox || this.graph.getContentBBox()
 
     const padding = NumberExt.normalizeSides(options.padding)
     if (options.width && options.height) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

解决 graph 在缩放情况下导出图片不全的问题

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.