### PR TITLE
fix: fix mousemove event fires on first mousedown

### DIFF
--- a/packages/x6/src/graph/view.ts
+++ b/packages/x6/src/graph/view.ts
@@ -166,6 +166,10 @@ export class GraphView extends View {
     this.setEventData<EventData.Moving>(e, {
       currentView: view || null,
       mouseMovedCount: 0,
+      startPosition: {
+        x: e.clientX,
+        y: e.clientY,
+      }
     })
     const ctor = this.constructor as typeof GraphView
     this.delegateDocumentEvents(ctor.documentEvents, e.data)
@@ -206,6 +210,16 @@ export class GraphView extends View {
 
   protected onMouseMove(evt: JQuery.MouseMoveEvent) {
     const data = this.getEventData<EventData.Moving>(evt)
+    
+    const startPosition = data.startPosition
+    if (
+      startPosition &&
+      startPosition.x === evt.clientX &&
+      startPosition.y === evt.clientY
+    ) {
+      return
+    }
+
     if (data.mouseMovedCount == null) {
       data.mouseMovedCount = 0
     }
@@ -626,6 +640,7 @@ export namespace GraphView {
 namespace EventData {
   export interface Moving {
     mouseMovedCount?: number
+    startPosition?: { x: number, y: number }
     currentView?: CellView | null
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

windows下页面没有获取焦点的情况下，mousedown事件之后紧接着会出现一个mousemove事件,这个是chrome的bug
https://bugs.chromium.org/p/chromium/issues/detail?id=721341&q=trigger%20mousemove%20event%20on%20first%20click&can=1

可在 [F2etest](https://f2etest.alibaba-inc.com/browser)上选择chrome浏览器访问demo进行复现：  https://codepen.io/MSCAU/pen/mzOBpX.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.