### PR TITLE
perf: ⚡️ add clientSize cache and setClass for reducing reflow

### DIFF
--- a/packages/x6/src/addon/scroller/index.ts
+++ b/packages/x6/src/addon/scroller/index.ts
@@ -37,6 +37,7 @@ export class Scroller extends View {
   protected cachedScrollLeft: number | null
   protected cachedScrollTop: number | null
   protected cachedCenterPoint: Point.PointLike | null
+  protected cachedClientSize: { width: number; height: number } | null
   protected delegatedHandlers: { [name: string]: Function }
 
   constructor(options: Scroller.Options) {
@@ -284,6 +285,17 @@ export class Scroller extends View {
     this.container.scrollTop = this.cachedScrollTop!
     this.cachedScrollLeft = null
     this.cachedScrollTop = null
+  }
+
+  protected storeClientSize() {
+    this.cachedClientSize = {
+      width: this.container.clientWidth,
+      height: this.container.clientHeight,
+    }
+  }
+
+  protected restoreClientSize() {
+    this.cachedClientSize = null
   }
 
   protected beforeManipulation() {
@@ -555,6 +567,8 @@ export class Scroller extends View {
 
     let localOptions: Scroller.CenterOptions | null | undefined
 
+    this.storeClientSize() // avoid multilple reflow
+
     if (typeof x === 'number' || typeof y === 'number') {
       localOptions = options
       const visibleCenter = this.getVisibleArea().getCenter()
@@ -595,7 +609,11 @@ export class Scroller extends View {
       Math.max(bottom, 0),
     )
 
-    return this.scrollToPoint(x, y, localOptions || undefined)
+    const result = this.scrollToPoint(x, y, localOptions || undefined)
+
+    this.restoreClientSize()
+
+    return result
   }
 
   centerContent(options?: Scroller.PositionContentOptions) {
@@ -1002,6 +1020,9 @@ export class Scroller extends View {
   }
 
   getClientSize() {
+    if (this.cachedClientSize) {
+      return this.cachedClientSize
+    }
     return {
       width: this.container.clientWidth,
       height: this.container.clientHeight,

--- a/packages/x6/src/view/view.ts
+++ b/packages/x6/src/view/view.ts
@@ -52,6 +52,13 @@ export abstract class View<EventArgs = any> extends Basecoat<EventArgs> {
 
   protected onRemove() {}
 
+  setClass(className: string | string[], elem: Element = this.container) {
+    elem.classList.value = Array.isArray(className)
+      ? className.join(' ')
+      : className
+    return
+  }
+
   addClass(className: string | string[], elem: Element = this.container) {
     this.$(elem).addClass(
       Array.isArray(className) ? className.join(' ') : className,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

* add clientSize cache `cacedClientSize` in scroller when resize to reduce reflow times
* add `setClass` method in view to enable set classList at onece to reduce reflow times

### Motivation and Context

Enhance performance by reduce reflow times.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.