### PR TITLE
fix: 🐛 splitbox component event (onResizerClick、onResizerDoubleClick)

### DIFF
--- a/packages/x6-react-components/src/split-box/splitbox.tsx
+++ b/packages/x6-react-components/src/split-box/splitbox.tsx
@@ -7,12 +7,12 @@ import { Resizer } from './resizer'
 export class SplitBox extends React.PureComponent<
   SplitBox.Props,
   SplitBox.State
-> {
+  > {
   private container: HTMLDivElement
   private box1Elem: HTMLDivElement
   private box2Elem: HTMLDivElement
-  private maskElem: HTMLDivElement
   private resizerElem: HTMLDivElement
+  private rootContainer: HTMLDivElement
 
   private minSize: number
   private maxSize: number
@@ -28,6 +28,12 @@ export class SplitBox extends React.PureComponent<
   UNSAFE_componentWillReceiveProps(nextProps: SplitBox.Props) {
     const nextState = this.getNextState(nextProps)
     this.setState(nextState)
+  }
+
+  componentDidMount() {
+    this.rootContainer = document.querySelector(
+      '.x6-split-box',
+    ) as HTMLDivElement
   }
 
   getNextState(props: SplitBox.Props): SplitBox.State {
@@ -154,26 +160,18 @@ export class SplitBox extends React.PureComponent<
         cursor = 'row-resize'
       }
     }
-
-    this.maskElem.style.cursor = cursor
+    this.rootContainer.style.cursor = cursor
   }
 
-  createMask() {
-    const mask = document.createElement('div')
-    mask.style.position = 'absolute'
-    mask.style.top = '0'
-    mask.style.right = '0'
-    mask.style.bottom = '0'
-    mask.style.left = '0'
-    mask.style.zIndex = '9999'
-    document.body.appendChild(mask)
-    this.maskElem = mask
+  frozenBox() {
+    this.box1Elem.style.pointerEvents = 'none'
+    this.box2Elem.style.pointerEvents = 'none'
   }
 
-  removeMask() {
-    if (this.maskElem.parentNode) {
-      this.maskElem.parentNode.removeChild(this.maskElem)
-    }
+  releaseBox() {
+    this.box1Elem.style.pointerEvents = 'auto'
+    this.box2Elem.style.pointerEvents = 'auto'
+    this.rootContainer.style.cursor = 'auto'
   }
 
   onMouseDown = () => {
@@ -183,9 +181,8 @@ export class SplitBox extends React.PureComponent<
     this.curSize = this.getPrimarySize()
     this.rawSize = this.curSize
     this.resizing = true
-
-    this.createMask()
     this.updateCursor(this.curSize, minSize, maxSize)
+    this.frozenBox()
   }
 
   onMouseMove = (deltaX: number, deltaY: number) => {
@@ -227,7 +224,7 @@ export class SplitBox extends React.PureComponent<
       }
 
       this.resizing = false
-      this.removeMask()
+      this.releaseBox()
     }
   }
 


### PR DESCRIPTION
修复无法触发splitbox onResizerClick 与onResizerDoubleClick 事件
原因： resizer mousedown 时候创建了个蒙层（用于防止拖动时候触发 box中的事件以及 拖动时候展示对应鼠标样式） 导致 click 时候点击到了蒙层 未点击到 resizer上
解决方法：  mousedown时候不创建蒙层  
1.通过修改 dom上pointerEvents 来防止拖动时候 触发box中事件
2.通过修改 根box的cursor 展示拖动中鼠标样式