### PR TITLE
feat: ✨ add x6-vue3-shape

### DIFF
--- a/packages/x6-vue3-shape/README.md
+++ b/packages/x6-vue3-shape/README.md
@@ -1,0 +1,101 @@
+# @antv/x6-vue3-shape
+
+> x6 shape for rendering vue3 components
+
+## Installation
+
+```shell
+# npm
+$ npm install @antv/x6-vue3-shape --save
+
+# yarn
+$ yarn add @antv/x6-vue3-shape
+```
+
+## Usage
+
+### useGraph
+```ts
+import { shallowRef, ref, onMounted } from 'vue'
+import { Graph } from '@antv/x6'
+import '@antv/x6-vue3-shape'
+import Comp from './Comp'
+
+export default function useGraph() {
+  const container = ref<HTMLElement | null>(null)
+  const graph = shallowRef<Graph | null>()
+  onMounted(() => {
+    if (container.value) {
+      graph.value = new Graph({
+        container: container.value,
+        panning: true,
+      })
+      graph.value.addNode({
+        id: 'node1',
+        x: 40,
+        y: 40,
+        width: 100,
+        height: 40,
+        shape: 'vue3-shape',
+        // here are 4 ways usages:
+        // 1. component: Comp
+        // 2. component: <Comp />
+        // 3. component: () => <Comp />
+        // 4. component: 'text node'
+        component: Comp,
+      })
+    }
+  })
+  return {
+    container,
+    graph,
+  }
+}
+```
+
+
+### usage in tsx
+
+```tsx
+import { defineComponent } from 'vue'
+import useGraph from './useGraph'
+
+export default defineComponent({
+  name: 'Home',
+  setup() {
+    const { container } = useGraph()
+    return () => {
+      return (
+        <div class="home">
+          <div class="home__container" ref={container}></div>
+        </div>
+      )
+    }
+  }
+})
+```
+
+### usage in vue sfc
+
+```vue
+<template>
+  <div ref="container">xxx</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import useGraph from './useGraph'
+
+export default defineComponent({
+  name: 'app',
+  setup() {
+    const { container } = useGraph()
+    return {
+      container,
+    }
+  }
+})
+
+</script>
+```
+

--- a/packages/x6-vue3-shape/package.json
+++ b/packages/x6-vue3-shape/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@antv/x6-vue3-shape",
+  "version": "1.0.0",
+  "description": "X6 shape for rendering vue3 components.",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "unpkg": "dist/x6-vue3-shape.js",
+  "jsdelivr": "dist/x6-vue3-shape.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "dist",
+    "es",
+    "lib"
+  ],
+  "keywords": [
+    "shape",
+    "vue3",
+    "vue-next",
+    "render",
+    "x6",
+    "antv"
+  ],
+  "scripts": {
+    "clean": "rimraf dist es lib",
+    "lint": "tslint -c tslint.json -p tsconfig.json --fix",
+    "watch": "watch 'yarn build' ./src",
+    "build:esm": "tsc --module esnext --target es2015 --outDir ./es",
+    "build:cjs": "tsc --module commonjs --target es5 --outDir ./lib",
+    "build:umd": "rollup -c",
+    "build": "run-p build:cjs build:esm build:umd",
+    "prebuild": "run-s lint clean",
+    "prepare": "yarn build",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "src/**/*.ts": [
+      "tslint -c tslint.json -p ./tsconfig.json --fix"
+    ]
+  },
+  "peerDependencies": {
+    "@antv/x6": ">=1.0.0",
+    "vue": ">=3.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.0",
+    "@rollup/plugin-replace": "^2.3.4",
+    "@rollup/plugin-typescript": "^8.1.0",
+    "@types/node": "^14.14.14",
+    "lint-staged": "^10.5.3",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^3.0.0",
+    "rollup": "^2.35.1",
+    "rollup-plugin-auto-external": "^2.0.0",
+    "rollup-plugin-filesize": "^9.1.0",
+    "rollup-plugin-terser": "^7.0.2",
+    "sinon": "^7.5.0",
+    "ts-jest": "^24.0.2",
+    "ts-node": "^9.1.1",
+    "tslint": "^6.1.3",
+    "typescript": "^4.1.2",
+    "vue": "^3.0.0",
+    "watch": "^1.0.2"
+  },
+  "author": {
+    "name": "bubkoo",
+    "email": "bubkoo.wy@gmail.com"
+  },
+  "contributors": [],
+  "license": "MIT",
+  "homepage": "https://github.com/antvis/x6",
+  "bugs": {
+    "url": "https://github.com/antvis/x6/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/antvis/x6.git",
+    "directory": "packages/x6-vue3-shape"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "dependencies": {
+    "vue": "^3.0.7"
+  }
+}

--- a/packages/x6-vue3-shape/rollup.config.js
+++ b/packages/x6-vue3-shape/rollup.config.js
@@ -1,0 +1,31 @@
+import { terser } from 'rollup-plugin-terser'
+import replace from '@rollup/plugin-replace'
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import filesize from 'rollup-plugin-filesize'
+import typescript from '@rollup/plugin-typescript'
+import autoExternal from 'rollup-plugin-auto-external'
+
+export default {
+  input: './src/index.ts',
+  output: [
+    {
+      name: 'X6VueShape',
+      format: 'umd',
+      file: 'dist/x6-vue-shape.js',
+      sourcemap: true,
+      globals: {
+        '@antv/x6': 'X6',
+      },
+    },
+  ],
+  plugins: [
+    typescript({ declaration: false }),
+    resolve(),
+    commonjs(),
+    replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+    terser(),
+    filesize(),
+    autoExternal(),
+  ],
+}

--- a/packages/x6-vue3-shape/src/hook.ts
+++ b/packages/x6-vue3-shape/src/hook.ts
@@ -1,0 +1,35 @@
+import { Graph, FunctionExt } from '@antv/x6'
+import { registry, Definition } from './registry'
+import { Vue3Shape } from './node'
+
+declare module '@antv/x6/lib/graph/hook' {
+  namespace Hook {
+    interface IHook {
+      getVue3Component(this: Graph, node: Vue3Shape): Definition
+    }
+  }
+  interface Hook {
+    getVue3Component(node: Vue3Shape): Definition
+  }
+}
+
+Graph.Hook.prototype.getVue3Component = function (node: Vue3Shape) {
+  const getVue3Component = this.options.getVue3Component
+
+  if (typeof getVue3Component === 'function') {
+    const ret = FunctionExt.call(getVue3Component, this.graph, node)
+    if (ret != null) {
+      return ret
+    }
+  }
+
+  let ret = node.getComponent()
+  if (typeof ret === 'string') {
+    const component = registry.get(ret)
+    if (component == null) {
+      return registry.onNotFound(ret)
+    }
+    ret = component
+  }
+  return ret as Definition
+}

--- a/packages/x6-vue3-shape/src/index.ts
+++ b/packages/x6-vue3-shape/src/index.ts
@@ -1,0 +1,4 @@
+import './hook'
+export * from './node'
+export * from './view'
+export * from './registry'

--- a/packages/x6-vue3-shape/src/node.ts
+++ b/packages/x6-vue3-shape/src/node.ts
@@ -102,6 +102,46 @@ export namespace Vue3Shape {
         textVerticalAnchor: 'middle',
       },
     },
+    propHooks(metadata: Properties) {
+      if (metadata.markup == null) {
+        const primer = metadata.primer
+        const useForeignObject = metadata.useForeignObject
+        if (primer != null || useForeignObject != null) {
+          metadata.markup = getMarkup(useForeignObject !== false, primer)
+          if (primer) {
+            if (metadata.attrs == null) {
+              metadata.attrs = {}
+            }
+            let attrs = {}
+            if (primer === 'circle') {
+              attrs = {
+                refCx: '50%',
+                refCy: '50%',
+                refR: '50%',
+              }
+            } else if (primer === 'ellipse') {
+              attrs = {
+                refCx: '50%',
+                refCy: '50%',
+                refRx: '50%',
+                refRy: '50%',
+              }
+            }
+
+            if (primer !== 'rect') {
+              metadata.attrs = ObjectExt.merge({}, metadata.attrs, {
+                body: {
+                  refWidth: null,
+                  refHeight: null,
+                  ...attrs,
+                },
+              })
+            }
+          }
+        }
+      }
+      return metadata
+    },
   })
   Node.registry.register('vue3-shape', Vue3Shape, true)
 }

--- a/packages/x6-vue3-shape/src/node.ts
+++ b/packages/x6-vue3-shape/src/node.ts
@@ -1,0 +1,107 @@
+import { Node, Markup, ObjectExt } from '@antv/x6'
+import { Definition } from './registry'
+
+export class Vue3Shape<
+  Properties extends Vue3Shape.Properties = Vue3Shape.Properties
+> extends Node {
+  get component() {
+    return this.getComponent()
+  }
+
+  getComponent(): Vue3Shape.Properties['component'] {
+    return this.store.get('component')
+  }
+
+  setComponent(
+    component: Vue3Shape.Properties['component'],
+    options: Node.SetOptions,
+  ) {
+    if (component == null) {
+      this.removeComponent(options)
+    } else {
+      this.store.set('component', component, options)
+    }
+    return this
+  }
+
+  removeComponent(options: Node.SetOptions = {}) {
+    this.store.remove('component', options)
+    return this
+  }
+
+  // static getMarkup: (
+  //   useForeignObject: boolean,
+  //   primer?: Vue3Shape.Primer,
+  // ) => Markup.JSONMarkup[]
+}
+
+export namespace Vue3Shape {
+  export type Primer =
+    | 'rect'
+    | 'circle'
+    | 'path'
+    | 'ellipse'
+    | 'polygon'
+    | 'polyline'
+  export interface Properties extends Node.Properties {
+    primer?: Primer
+    useForeignObject?: boolean
+    component?: Definition | string
+  }
+}
+
+function getMarkup(
+  useForeignObject: boolean,
+  primer: Vue3Shape.Primer = 'rect',
+) {
+  const markup: Markup.JSONMarkup[] = [
+    {
+      tagName: primer,
+      selector: 'body',
+    },
+  ]
+
+  if (useForeignObject) {
+    markup.push(Markup.getForeignObjectMarkup())
+  } else {
+    markup.push({
+      tagName: 'g',
+      selector: 'content',
+    })
+  }
+
+  markup.push({
+    tagName: 'text',
+    selector: 'label',
+  })
+
+  return markup
+}
+
+export namespace Vue3Shape {
+  Vue3Shape.config<Properties>({
+    view: 'vue3-shape-view',
+    markup: getMarkup(true),
+    attrs: {
+      body: {
+        fill: 'none',
+        stroke: 'none',
+        refWidth: '100%',
+        refHeight: '100%',
+      },
+      fo: {
+        refWidth: '100%',
+        refHeight: '100%',
+      },
+      label: {
+        fontSize: 14,
+        fill: '#333',
+        refX: '50%',
+        refY: '50%',
+        textAnchor: 'middle',
+        textVerticalAnchor: 'middle',
+      },
+    },
+  })
+  Node.registry.register('vue3-shape', Vue3Shape, true)
+}

--- a/packages/x6-vue3-shape/src/registry.ts
+++ b/packages/x6-vue3-shape/src/registry.ts
@@ -1,0 +1,24 @@
+import { Graph, Node, Registry } from '@antv/x6'
+import { DefineComponent } from 'vue'
+
+export type Definition =
+  | JSX.Element
+  | DefineComponent
+  | ((
+      this: Graph,
+      node: Node,
+    ) => JSX.Element | DefineComponent | null | undefined)
+
+export const registry = Registry.create<Definition>({
+  type: 'vue3 component',
+})
+
+declare module '@antv/x6/lib/graph/graph' {
+  namespace Graph {
+    let registerVue3Component: typeof registry.register
+    let unregisterVue3Component: typeof registry.unregister
+  }
+}
+
+Graph.registerVue3Component = registry.register
+Graph.unregisterVue3Component = registry.unregister

--- a/packages/x6-vue3-shape/src/shims-vue.d.ts
+++ b/packages/x6-vue3-shape/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/packages/x6-vue3-shape/src/view.ts
+++ b/packages/x6-vue3-shape/src/view.ts
@@ -1,0 +1,75 @@
+import { NodeView } from '@antv/x6'
+import { Vue3Shape } from './node'
+import { h, createApp, App } from 'vue'
+
+export class Vue3ShapeView extends NodeView<Vue3Shape> {
+  protected init() {
+    super.init()
+  }
+
+  getComponentContainer() {
+    return this.selectors.foContent as HTMLDivElement
+  }
+
+  confirmUpdate(flag: number) {
+    const ret = super.confirmUpdate(flag)
+    return this.handleAction(ret, Vue3ShapeView.action, () =>
+      this.renderVue3Component(),
+    )
+  }
+
+  protected vue3App: App | null = null
+
+  renderVue3Component() {
+    // unmount
+    this.unMountVue3Component()
+    const root = this.getComponentContainer()
+    const node = this.cell
+    const graph = this.graph
+
+    if (root) {
+      const component = this.graph.hook.getVue3Component(node)
+      this.vue3App = createApp({
+        render() {
+          return h(component)
+        },
+        provide() {
+          return {
+            getGraph: () => graph,
+            getNode: () => node,
+          }
+        },
+      })
+
+      this.vue3App.mount(root)
+    }
+  }
+
+  protected unMountVue3Component() {
+    const root = this.getComponentContainer()
+    if (this.vue3App) {
+      this.vue3App.unmount()
+    }
+    return root
+  }
+
+  // @NodeView.dispose()
+  dispose() {
+    // this.unMountVue3Component()
+    NodeView.dispose()
+    this.unMountVue3Component()
+  }
+}
+
+export namespace Vue3ShapeView {
+  export const action = 'vue3' as any
+
+  Vue3ShapeView.config({
+    bootstrap: [action],
+    actions: {
+      component: action,
+    },
+  })
+
+  NodeView.registry.register('vue3-shape-view', Vue3ShapeView, true)
+}

--- a/packages/x6-vue3-shape/tsconfig.json
+++ b/packages/x6-vue3-shape/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json",
+}

--- a/packages/x6-vue3-shape/tslint.json
+++ b/packages/x6-vue3-shape/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tslint.json"
+}


### PR DESCRIPTION
Added X6-Vue3-Shape to support rendering Vue3 components

<!--- Provide a general summary of your changes in the Title above -->

### Description

Added x6-vue3-shape code to enable X6 to render Vue3 components.
<!--- Describe your changes in detail -->

### Motivation and Context
X6 currently does not support VUE3 components. Since the official version of Vue3 has been available for some time, some people may want to render Vue3 components with X6, so I developed this plugin using the React and Vue2.x related source code implementations.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.