### PR TITLE
fix: 🐛 make sure css resource is disposed  after all instance disposed

### DIFF
--- a/packages/x6/src/addon/dnd/index.ts
+++ b/packages/x6/src/addon/dnd/index.ts
@@ -432,7 +432,13 @@ export class Dnd extends View {
   protected onRemove() {
     if (this.draggingGraph) {
       this.draggingGraph.view.remove()
+      this.draggingGraph.dispose()
     }
+  }
+
+  @View.dispose()
+  dispose() {
+    this.remove()
   }
 }
 

--- a/packages/x6/src/addon/minimap/index.ts
+++ b/packages/x6/src/addon/minimap/index.ts
@@ -123,6 +123,7 @@ export class MiniMap extends View {
   protected onRemove() {
     this.targetGraph.view.remove()
     this.stopListening()
+    this.targetGraph.dispose()
   }
 
   protected updatePaper(width: number, height: number): this

--- a/packages/x6/src/graph/css.ts
+++ b/packages/x6/src/graph/css.ts
@@ -18,9 +18,13 @@ export class CSSManager extends Base {
 
 export namespace CSSManager {
   let styleElement: HTMLStyleElement | null
+  let counter = 0
 
   export function ensure() {
-    if (styleElement == null && !Platform.isApplyingHMR()) {
+    counter = counter + 1
+    if (counter > 1) return
+
+    if (!Platform.isApplyingHMR()) {
       styleElement = document.createElement('style')
       styleElement.setAttribute('type', 'text/css')
       styleElement.textContent = content
@@ -33,6 +37,9 @@ export namespace CSSManager {
   }
 
   export function clean() {
+    counter = counter - 1
+    if (counter > 0) return
+
     if (styleElement && styleElement.parentNode) {
       styleElement.parentNode.removeChild(styleElement)
     }


### PR DESCRIPTION

### Description

In current version, css style will be removed after every instance is disposed. this will break alive graph instances if there exists multiple x6 graph instances.

Import a single counter variable to ensure that css style is removed util  all instances are disposed.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.