### PR TITLE
fix: 🐛 fix node translation with selected children

### DIFF
--- a/packages/x6/src/addon/selection/index.ts
+++ b/packages/x6/src/addon/selection/index.ts
@@ -477,7 +477,11 @@ export class Selection extends View<Selection.EventArgs> {
   ) {
     const map: { [id: string]: boolean } = {}
     this.collection.toArray().forEach((cell) => {
-      if (!map[cell.id] && cell !== exclude) {
+      if (
+        !map[cell.id] &&
+        cell !== exclude &&
+        !otherOptions?.handledTranslation?.includes(cell)
+      ) {
         const options = {
           ...otherOptions,
           selection: this.cid,

--- a/packages/x6/src/model/cell.ts
+++ b/packages/x6/src/model/cell.ts
@@ -1531,6 +1531,7 @@ export namespace Cell {
     tx?: number
     ty?: number
     translateBy?: string | number
+    handledTranslation?: Cell[]
   }
 
   export interface AddToolOptions extends SetOptions {

--- a/packages/x6/src/model/node.ts
+++ b/packages/x6/src/model/node.ts
@@ -387,6 +387,11 @@ export class Node<
     } else {
       this.startBatch('translate', options)
       this.store.set('position', translatedPosition, options)
+      options.handledTranslation = [this]
+      const children = this.children
+      if (children?.length) {
+        options.handledTranslation.push(...children)
+      }
       this.eachChild((child) => child.translate(tx, ty, options))
       this.stopBatch('translate', options)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

When node translate, its children make unnecessary translation by `onNodePositionChanged` in selection addon when selected. To avoid that, add flag to translation options to filter those translated nodes.

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.