### PR TITLE
fix: 🐛 fix bbox calc error in firefox

### DIFF
--- a/packages/x6/src/util/dom/text.ts
+++ b/packages/x6/src/util/dom/text.ts
@@ -6,6 +6,7 @@ import { Text } from '../text'
 import { attr } from './attr'
 import { Vector } from '../vector'
 import { createSvgElement, empty, remove } from './elem'
+import { Platform } from '../platform'
 
 function createTextPathNode(
   attrs: { d?: string; 'xlink:href'?: string },
@@ -632,7 +633,11 @@ export function breakText(
 
         lineHeight = heightValue.value
         if (heightValue.unit === 'em') {
-          lineHeight *= telem.getBBox().height
+          if (Platform.IS_FIREFOX) {
+            lineHeight *= tspan.getBBox().height
+          } else {
+            lineHeight *= telem.getBBox().height
+          }
         }
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

在 firefox 下计算 text 的 bbox 有误差，修改成直接计算 tspan 的 bbox

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.