### PR TITLE
fix: 🐛 translateSelectionNodes is only triggered manually

### DIFF
--- a/packages/x6/src/addon/selection/index.ts
+++ b/packages/x6/src/addon/selection/index.ts
@@ -124,7 +124,12 @@ export class Selection extends View<Selection.EventArgs> {
     node,
     options,
   }: Collection.EventArgs['node:change:position']) {
-    if (this.options.showNodeSelectionBox !== true && !this.translating) {
+    // Executes only if showNodeSelectionBox is false and is triggered manually
+    if (
+      this.options.showNodeSelectionBox !== true &&
+      !this.translating &&
+      options.ui
+    ) {
       this.translating = true
       const current = node.position()
       const previous = node.previous('position')!
@@ -538,7 +543,7 @@ export class Selection extends View<Selection.EventArgs> {
 
   protected notifyBoxEvent<
     K extends keyof Selection.BoxEventArgs,
-    T extends JQuery.TriggeredEvent,
+    T extends JQuery.TriggeredEvent
   >(name: K, e: T, x: number, y: number) {
     const data = this.getEventData<EventData.SelectionBox>(e)
     const view = data.activeView


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

translateSelectionNodes 只有手动触发才会执行，解决代码触发某个选中节点平移时，造成的多个节点响应问题。

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.