### PR TITLE
feat: ✨ optimize selection event handle

### DIFF
--- a/packages/x6/src/graph/options.ts
+++ b/packages/x6/src/graph/options.ts
@@ -729,6 +729,7 @@ export namespace Options {
       rubberband: false,
       rubberNode: true,
       rubberEdge: false, // next version will set to true
+      pointerEvents: 'auto',
       multiple: true,
       movable: true,
       strict: false,

--- a/packages/x6/src/model/cell.ts
+++ b/packages/x6/src/model/cell.ts
@@ -1542,7 +1542,6 @@ export namespace Cell {
     tx?: number
     ty?: number
     translateBy?: string | number
-    handledTranslation?: Cell[]
   }
 
   export interface AddToolOptions extends SetOptions {

--- a/packages/x6/src/model/node.ts
+++ b/packages/x6/src/model/node.ts
@@ -383,19 +383,21 @@ export class Node<
         ...options.transition,
         interp: Interp.object,
       })
-      this.eachChild((child) => child.translate(tx, ty, options))
+      this.eachChild((child) => {
+        const excluded = options.exclude?.includes(child)
+        if (!excluded) {
+          child.translate(tx, ty, options)
+        }
+      })
     } else {
       this.startBatch('translate', options)
       this.store.set('position', translatedPosition, options)
-      options.handledTranslation = options.handledTranslation || []
-      if (!options.handledTranslation.includes(this)) {
-        options.handledTranslation.push(this)
-        const children = this.children
-        if (children?.length) {
-          options.handledTranslation.push(...children)
+      this.eachChild((child) => {
+        const excluded = options.exclude?.includes(child)
+        if (!excluded) {
+          child.translate(tx, ty, options)
         }
-      }
-      this.eachChild((child) => child.translate(tx, ty, options))
+      })
       this.stopBatch('translate', options)
     }
 
@@ -1018,6 +1020,7 @@ export namespace Node {
   export interface TranslateOptions extends Cell.TranslateOptions {
     transition?: boolean | Animation.StartOptions<Point.PointLike>
     restrict?: Rectangle.RectangleLike | null
+    exclude?: Cell[]
   }
 
   export interface RotateOptions extends SetOptions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

解决下面三个问题：
1. 开启 showSelectionBox 后，选中节点无法响应节点事件 https://github.com/antvis/X6/issues/1079 https://github.com/antvis/X6/issues/962  这里增加新的配置项：`pointerEvents`
2. 不开启 showSelectionBox，在群组中，移动节点，造成循环移动
3. 选中节点平移时，如果开启 restrict，要考虑所有选中节点是否超过限制

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.