### PR TITLE
fix: add document click listener only in capture phase

### DIFF
--- a/packages/x6-react-components/src/menubar/item.tsx
+++ b/packages/x6-react-components/src/menubar/item.tsx
@@ -122,6 +122,7 @@ class MenubarItemInner extends React.PureComponent<
         document.documentElement,
         'click',
         this.onDocumentClick,
+        true
       ).remove
     }
   }

--- a/packages/x6-react-components/src/menubar/menubar.tsx
+++ b/packages/x6-react-components/src/menubar/menubar.tsx
@@ -35,6 +35,7 @@ export class Menubar extends React.PureComponent<Menubar.Props, Menubar.State> {
         document.documentElement,
         'click',
         this.onDocumentClick,
+        true
       ).remove
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

menubar 组件存在 bug，鼠标点击 menubar.item 后 menu 不会出现

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

由于事件先捕获，后冒泡，导致 menubar/menubar.item active 之后立即去给 document 绑定 click 事件，document 会在冒泡阶段触发 listener 函数，将 active 修改为 false，导致 menu 不会出现

这个 PR 修改了 document click listener 仅在捕获阶段触发来解决这个问题

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.