### PR TITLE
fix: segments & vertices tool add onChanged callback

### DIFF
--- a/packages/x6/src/registry/tool/segments.ts
+++ b/packages/x6/src/registry/tool/segments.ts
@@ -325,6 +325,8 @@ export class Segments extends ToolsView.ToolItem<EdgeView, Segments.Options> {
       edgeView.notifyMouseUp(normalizedEvent, coords.x, coords.y)
     }
     edgeView.checkMouseleave(normalizedEvent)
+
+    options.onChanged && options.onChanged({ edge: edgeView.cell, edgeView })
   }
 
   protected updateHandle(
@@ -379,6 +381,7 @@ export namespace Segments {
     ) => Edge.TerminalCellData['anchor']
     createHandle?: (options: Handle.Options) => Handle
     processHandle?: (handle: Handle) => void
+    onChanged?: (options: { edge: Edge, edgeView: EdgeView }) => void
   }
 
   export interface EventData {

--- a/packages/x6/src/registry/tool/vertices.ts
+++ b/packages/x6/src/registry/tool/vertices.ts
@@ -3,6 +3,7 @@ import { Point } from '../../geometry'
 import { Graph } from '../../graph'
 import { View } from '../../view/view'
 import { EdgeView } from '../../view/edge'
+import { Edge } from './../../model/edge'
 import { ToolsView } from '../../view/tool'
 import { Attr } from '../attr'
 
@@ -206,6 +207,8 @@ export class Vertices extends ToolsView.ToolItem<EdgeView, Vertices.Options> {
     }
 
     edgeView.checkMouseleave(evt)
+
+    options.onChanged && options.onChanged({ edge: edgeView.cell, edgeView })
   }
 
   protected snapVertex(vertex: Point.PointLike, index: number) {
@@ -284,6 +287,7 @@ export namespace Vertices {
     attrs?: Attr.SimpleAttrs | ((handle: Handle) => Attr.SimpleAttrs)
     createHandle?: (options: Handle.Options) => Handle
     processHandle?: (handle: Handle) => void
+    onChanged?: (options: { edge: Edge, edgeView: EdgeView }) => void
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
edge 相关的 segment 和 vertices tool 需要有一个 onChanged 回调，来渲染 & 保存顶点数据

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.