### PR TITLE
fix: 🐛 unexpected user feedback in "vertices" edge tool

### DIFF
--- a/packages/x6/src/registry/tool/vertices.ts
+++ b/packages/x6/src/registry/tool/vertices.ts
@@ -262,7 +262,7 @@ export class Vertices extends ToolsView.ToolItem<EdgeView, Vertices.Options> {
     edgeView.cell.startBatch('add-vertex', { ui: true, toolId: this.cid })
     const index = edgeView.getVertexIndex(vertex.x, vertex.y)
     this.snapVertex(vertex, index)
-    edgeView.cell.setVertexAt(index, vertex, {
+    edgeView.cell.insertVertex(vertex, index, {
       ui: true,
       toolId: this.cid,
     })


### PR DESCRIPTION
In the `vertices` tool, allow inserting points anywhere on the edge by changing the method used for vertex addition.

### Description

Currently the `vertices` EdgeTool does not allow inserting new points between exising points, only at the end of the edge.

Fix by using `insertVertex` instead of `setVertexAt` such that a new vertex is guaranteed to be added.

### Motivation and Context

The current behavior is unnatural for end-users, because one would expect the tool to create a point wherever they click on the edge.

Fix #1679

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.