### PR TITLE
fix: minimap 在非 scroller 模式下 translate 未同步问题

### DIFF
--- a/packages/x6/src/addon/minimap/index.ts
+++ b/packages/x6/src/addon/minimap/index.ts
@@ -126,7 +126,7 @@ export class MiniMap extends View {
         this.updateViewport,
       )
     } else {
-      this.sourceGraph.on('translate', this.updateViewport, this)
+      this.sourceGraph.on('translate', this.onSourceTranslate, this)
     }
     this.sourceGraph.on('resize', this.updatePaper, this)
     this.delegateEvents({
@@ -141,7 +141,7 @@ export class MiniMap extends View {
     if (this.scroller) {
       this.$graphContainer.off(this.getEventNamespace())
     } else {
-      this.sourceGraph.off('translate', this.updateViewport, this)
+      this.sourceGraph.off('translate', this.onSourceTranslate, this)
     }
     this.sourceGraph.off('resize', this.updatePaper, this)
     this.undelegateEvents()
@@ -187,6 +187,11 @@ export class MiniMap extends View {
     this.targetGraph.scale(ratio, ratio)
     this.updateViewport()
     return this
+  }
+
+  protected onSourceTranslate() {
+    const { width, height } = this.sourceGraph.options
+    this.updatePaper(width, height)
   }
 
   protected updateViewport() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

在非 scroller 模式下 minimap 不会同步 sourceGraph 的 translate 坐标。导致：

1. 拖动 sourceGraph 不会同步到 minimap 
2. 如果对 sourceGraph 做一个自动居中，minimap 一开始的展示就不正确

复现例子：https://codesandbox.io/s/x6-minimap-translate-issue-hb0mi0?file=/src/app.tsx

修复方式：在 translate 事件时，调用 updatePaper。

修复前：

<img width="629" alt="image" src="https://user-images.githubusercontent.com/10339692/154216125-e9086f75-d9e0-4937-a7f1-f9865e499e2f.png">


修复后：

<img width="707" alt="image" src="https://user-images.githubusercontent.com/10339692/154215403-b4590a44-cd73-41a6-9af3-585f1633ece2.png">
