### PR TITLE
fix: 🐛 fix scroller resize size miscalculation when graph resize

### DIFF
--- a/packages/x6/src/addon/scroller/index.ts
+++ b/packages/x6/src/addon/scroller/index.ts
@@ -1021,8 +1021,8 @@ export class Scroller extends View {
   }
 
   resize(width?: number, height?: number) {
-    let w = width != null ? width : this.container.clientWidth
-    let h = height != null ? height : this.container.clientHeight
+    let w = width != null ? width : this.container.offsetWidth
+    let h = height != null ? height : this.container.offsetHeight
 
     if (typeof w === 'number') {
       w = Math.round(w)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

当画图面板resize时，scroller也会重新计算宽高。但是计算的宽高值不包含滚动条的宽度，导致计算的宽高值在多次resize反复下，变得越来越小

### Motivation and Context
![X6 scroller resize](https://user-images.githubusercontent.com/26325346/161885211-a7a0e572-d04f-4ce6-8773-3540462108a3.gif)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.