### PR TITLE
fix: remove the browserslist configuration in package.json

### DIFF
--- a/packages/x6-geometry/package.json
+++ b/packages/x6-geometry/package.json
@@ -91,11 +91,6 @@
     "tslib": "^2.3.1",
     "typescript": "^4.4.3"
   },
-  "browserslist": [
-    "last 2 versions",
-    "Firefox ESR",
-    "> 1%"
-  ],
   "author": {
     "name": "bubkoo",
     "email": "bubkoo.wy@gmail.com"

--- a/packages/x6-vector/package.json
+++ b/packages/x6-vector/package.json
@@ -103,11 +103,6 @@
     "tslib": "^2.3.1",
     "typescript": "^4.4.3"
   },
-  "browserslist": [
-    "last 2 versions",
-    "Firefox ESR",
-    "> 1%"
-  ],
   "author": {
     "name": "bubkoo",
     "email": "bubkoo.wy@gmail.com"

--- a/packages/x6/package.json
+++ b/packages/x6/package.json
@@ -134,11 +134,6 @@
     "tslib": "^2.3.1",
     "typescript": "^4.4.3"
   },
-  "browserslist": [
-    "last 2 versions",
-    "Firefox ESR",
-    "> 1%"
-  ],
   "author": {
     "name": "bubkoo",
     "email": "bubkoo.wy@gmail.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

删除 `x6` `x6-vector` `x6-geometry` 三个包 `package.json` 文件中的 browserslist 配置。

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

在 X6 的源码中，有尝试检测当前执行环境，是否原生支持 class 风格的判断代码。  
https://github.com/antvis/x6/blob/master/packages/x6/src/util/object/inherit.ts#L31  
```
class A {}
const isNativeClass =
  /^\s*class\s+/.test(`${A}`) || /^\s*class\s*\{/.test(`${class {}}`)
```

在 @antv/x6@1.31.4 包中，其 es 目录中，这段代码是 class 风格的。  
/.../node_modules/@antv/x6/es/util/object/inherit.js  
```
class A {
}
const isNativeClass = /^\s*class\s+/.test(`${A}`) || /^\s*class\s*\{/.test(`${class {
}}`);
``` 

其 lib 目录中，这段代码是 function 风格的。  
/.../node_modules/@antv/x6/lib/util/object/inherit.js  
```
var A = /** @class */ (function () {
    function A() {
    }
    return A;
}());
var isNativeClass = /^\s*class\s+/.test("" + A) || /^\s*class\s*\{/.test("" + /** @class */ (function () {
    function class_1() {
    }
    return class_1;
}()));
```

在 X6 被 webpack 经 babel 编译后，这段代码已经是 function 风格了。  
http://localhost:8080/.../node_modules/@antv/x6/es/util/object/inherit.js  
```
var A = /*#__PURE__*/_createClass(function A() {
  _classCallCheck(this, A);
});

var isNativeClass = /^\s*class\s+/.test("".concat(A)) || /^\s*class\s*\{/.test("".concat( /*#__PURE__*/function () {
  function _class() {
    _classCallCheck(this, _class);
  }

  return _createClass(_class);
}()));
```

于是，isNativeClass 变量值就永远是 false，后续代码只会使用 function 方式加载。  

---

而插件 @antv/x6-react-shape@1.6.0 包中，其 es 目录中是 class 风格的。  
/.../node_modules/@antv/x6-react-shape/es/node.js  
```
class ReactShape extends Node {}
```

其 lib 目录中是 function 风格。  
/.../node_modules/@antv/x6-react-shape/lib/node.js  
```
var ReactShape = /** @class */ (function (_super) {}(x6_1.Node));
```

但被 webpack 经 babel 编译后，这段代码却还是 class 风格的。这就很奇怪了。  
http://localhost:8080/.../node_modules/@antv/x6-react-shape/es/node.js  
```
class ReactShape extends Node {}
```

---

经进一对比发现，@antv/x6-react-shape 比 @antv/x6 的 package.json 文件中，少了 browserslist 配置。  
/.../node_modules/@antv/x6/package.json  
```
  "browserslist": [
    "last 2 versions",
    "Firefox ESR",
    "> 1%"
  ],
```

根据 browserslist 的[配置查找规则](https://github.com/browserslist/browserslist/blob/main/node.js#L313)，可知使用了所在项目根目录的 .browserslistrc 文件。  
从而导致 @antv/x6-react-shape 出现了与 @antv/x6 不一致的编译结果。  
/.../.browserslistrc   
```
[production]
defaults

[development]
last 1 chrome version
last 1 firefox version
last 1 safari version

```

---

临时的修复方案，可以直接引用 @antv/x6-react-shape/lib 下文件。  
根本的修复方案，不要在 @antv/x6 的 package.json 文件中定义 browserslist 配置。而是完全交由库的使用者配置。  
这样也可避免库的使用者希望为现代浏览器，打包 class 风格代码时，却在输出的文件中，夹杂了来自 @antv/x6 的 function 风格代码。  

涉及到的 issues 和 pull  
https://github.com/antvis/X6/issues/1614  
https://github.com/antvis/X6/issues/1670  
https://github.com/antvis/X6/issues/1260  
https://github.com/antvis/X6/issues/1263  
https://github.com/antvis/X6/pull/585  
https://github.com/antvis/X6/pull/1266  
https://github.com/antvis/X6/pull/1921  

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.