### PR TITLE
docs: update api description of addTools

### DIFF
--- a/sites/x6-sites/docs/api/model/cell.zh.md
+++ b/sites/x6-sites/docs/api/model/cell.zh.md
@@ -2728,6 +2728,11 @@ addTools(
   items: Cell.ToolItem | Cell.ToolItem[],
   options?: Cell.AddToolOptions,
 ): this
+addTools(
+  items: Cell.ToolItem | Cell.ToolItem[],
+  name: string,
+  options?: Cell.AddToolOptions,
+): this
 ```
 
 添加小工具。
@@ -2737,6 +2742,7 @@ addTools(
 | 名称             | 类型                             | 必选 | 默认值  | 描述                                                                                                                   |
 |------------------|----------------------------------|:----:|---------|----------------------------------------------------------------------------------------------------------------------|
 | items            | Cell.ToolItem \| Cell.ToolItem[] |      |         | [NodeTool](/zh/docs/api/registry/node-tool#presets) 或 [EdgeTool](/zh/docs/api/registry/edge-tool#presets) 中定义的小工具。                 |
+| name             | string                           |      | `null`  | 定义该组工具的别称，可以作为`hasTools(name)`的参数                       |
 | options.reset    | boolean                          |      | `false` | 是否清空工具集，默认向工具集追加小工具。                                                                                 |
 | options.local    | boolean                          |      | `false` | 工具是否渲染到节点/边的容器中，默认为 `false`，所有工具会渲染在 `x6-graph-svg-decorator` 下面，只有在 `options.reset` 为 `true` 为时生效                                                                            |
 | options.silent   | boolean                          |      | `false` | 为 `true` 时不触发 `'change:tools'` 事件和小工具重绘。                                                              |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
![addTools的源码部分](https://user-images.githubusercontent.com/43718732/167153300-50dd7388-9afa-4b5d-8d17-42cac81064e5.png)
addTools函数被重载，第二个参数还可以是工具组的别称，但是文档里没有提及

### Motivation and Context

在学习[边工具demo](https://x6.antv.vision/zh/examples/edge/tool#vertices)时，误以为`onhover`是另一个工具名称，查看api文档时发现工具组应该用数组包裹起来，于是认为可能是options，可是options应该是键值对而非字符串。查阅源码后发现第二个参数可以是这组添加的工具的别称，作为`hasTools(name)`的参数。

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.