### PR TITLE
fix: 🐛 not rerender tools when edge update

### DIFF
--- a/packages/x6/src/view/edge.ts
+++ b/packages/x6/src/view/edge.ts
@@ -202,6 +202,7 @@ export class EdgeView<
     this.renderMarkup()
     this.renderLabels()
     this.update()
+    this.renderExternalTools()
 
     return this
   }
@@ -541,12 +542,7 @@ export class EdgeView<
     this.updateLabelPositions()
     this.updateToolsPosition()
     this.updateArrowheadMarkers()
-
-    if (options.toolId == null) {
-      this.renderExternalTools()
-    } else {
-      this.updateTools(options)
-    }
+    this.updateTools(options)
 
     return this
   }

--- a/packages/x6/src/view/tool.ts
+++ b/packages/x6/src/view/tool.ts
@@ -327,7 +327,7 @@ export namespace ToolsView {
 
     protected cellView: TargetView
 
-    protected visible: boolean
+    protected visible = true
 
     protected childNodes: KeyValue<Element>
 
@@ -440,7 +440,7 @@ export namespace ToolsView {
     }
 
     isVisible() {
-      return this.visible
+      return !!this.visible
     }
 
     focus() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

don't apply renderExternalTools when edge update. Close https://github.com/antvis/X6/issues/2071

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.