### PR TITLE
fix: 🐛 get different DOMRect on same SVGElement

### DIFF
--- a/packages/x6/src/util/dom/geom.ts
+++ b/packages/x6/src/util/dom/geom.ts
@@ -91,7 +91,9 @@ export function getBBox(
 
   if (!recursive) {
     try {
-      outputBBox = elem.getBBox()
+      // getBBox on rect to exclude size of text
+      const rect = elem.children[0] as SVGGraphicsElement
+      outputBBox = rect.getBBox()
     } catch (e) {
       outputBBox = {
         x: elem.clientLeft,


### PR DESCRIPTION
修复更新边时，重新计算相同 svgElement 时 getBBox 结果与首次加载时不一致

### Description

调用 updateAttrs 后会引发节点相关联的边更新，而第二次之后得到的矩形大小与首次生成的并不一致（多出了 text 的大小），所以在 getBBox 的时候我用 `elem` 下的子节点 `rect` 来获取矩形的数据来使生产的 Rectangle 与首次的保持一致。

### Motivation and Context

Closes #2040

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.