### PR TITLE
fix: 🐛 auto zoom minimap graph to fit content

### DIFF
--- a/packages/x6/src/addon/minimap/index.ts
+++ b/packages/x6/src/addon/minimap/index.ts
@@ -131,6 +131,9 @@ export class MiniMap extends View {
     } else {
       this.sourceGraph.on('translate', this.onSourceGraphTransform, this)
       this.sourceGraph.on('scale', this.onSourceGraphTransform, this)
+      this.sourceGraph.on('cell:added', this.zoomToFit, this)
+      this.sourceGraph.on('cell:removed', this.zoomToFit, this)
+      this.sourceGraph.on('reseted', this.zoomToFit, this)
     }
     this.sourceGraph.on('resize', this.updatePaper, this)
     this.delegateEvents({
@@ -147,6 +150,9 @@ export class MiniMap extends View {
     } else {
       this.sourceGraph.off('translate', this.onSourceGraphTransform, this)
       this.sourceGraph.off('scale', this.onSourceGraphTransform, this)
+      this.sourceGraph.off('cell:added', this.zoomToFit, this)
+      this.sourceGraph.off('cell:removed', this.zoomToFit, this)
+      this.sourceGraph.off('reseted', this.zoomToFit, this)
     }
     this.sourceGraph.off('resize', this.updatePaper, this)
     this.undelegateEvents()
@@ -167,6 +173,10 @@ export class MiniMap extends View {
         this.sourceGraph.options.height,
       )
     }
+  }
+
+  protected zoomToFit() {
+    this.targetGraph.zoomToFit()
   }
 
   protected updatePaper(width: number, height: number): this


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

In panning mode, minimap grpah not show the all shapes in content view, so listen cell:added cell:removed reseted events to zoom minimap graph to fit content.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.