### PR TITLE
perf: use native SVG elements in snapline instead of DOM elements and jQuery

### DIFF
--- a/packages/x6-geometry/src/version.ts
+++ b/packages/x6-geometry/src/version.ts
@@ -3,5 +3,5 @@
 /**
  * Auto generated version file, do not modify it!
  */
-const version = '1.0.8'
+const version = '1.0.12'
 export { version }

--- a/packages/x6/src/addon/snapline/index.less
+++ b/packages/x6/src/addon/snapline/index.less
@@ -3,25 +3,12 @@
 @snapline-prefix-cls: ~'@{x6-prefix}-widget-snapline';
 
 .@{snapline-prefix-cls} {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  position: relative;
   pointer-events: none;
 
   &-vertical,
   &-horizontal {
-    position: absolute;
-    opacity: 1;
-    pointer-events: none;
-  }
-
-  &-horizontal {
-    border-bottom: 1px solid #2ecc71;
-  }
-
-  &-vertical {
-    border-right: 1px solid #2ecc71;
+    stroke: #2ecc71;
+    stroke-width: 1px;
   }
 }

--- a/packages/x6/src/style/raw.ts
+++ b/packages/x6/src/style/raw.ts
@@ -811,24 +811,13 @@ export const content = `.x6-graph {
   background-color: #6a6b8a;
 }
 .x6-widget-snapline {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  position: relative;
   pointer-events: none;
 }
 .x6-widget-snapline-vertical,
 .x6-widget-snapline-horizontal {
-  position: absolute;
-  opacity: 1;
-  pointer-events: none;
-}
-.x6-widget-snapline-horizontal {
-  border-bottom: 1px solid #2ecc71;
-}
-.x6-widget-snapline-vertical {
-  border-right: 1px solid #2ecc71;
+  stroke: #2ecc71;
+  stroke-width: 1px;
 }
 .x6-widget-stencil {
   position: absolute;

--- a/packages/x6/src/view/node.ts
+++ b/packages/x6/src/view/node.ts
@@ -839,7 +839,7 @@ export class NodeView<
     }
 
     // Filter the nodes which is invisiable
-    candidates = candidates.filter((candidate) => candidate.visible);
+    candidates = candidates.filter((candidate) => candidate.visible)
 
     let newCandidateView = null
     const prevCandidateView = data.candidateEmbedView


### PR DESCRIPTION
### Description

Update `x6-snapline` to draw its lines as `<path>`s in a new SVG document next to the graph layer instead of `<div>`s in a `<div>` layer.

在 `x6-snapline` 中使用 SVG `<path>` 而不是 DOM 元素来绘制对齐线。

### Motivation and Context

SVG is much more performant in drawing lines (as expected) compared to manipulating the DOM tree and CSS positioning. This also avoids the use of jQuery and (hopefully) prevents any unexpected DOM reflow.

前一版本的对齐线是通过操纵 DOM 元素及它们的 CSS 绝对位置来绘制线条，与之相比 SVG 更适合这个任务。更新同时也去除了 jQuery 的使用。

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.