### PR TITLE
fix: :bug: Fixed the bug that node position was confused when the sel…

### DIFF
--- a/packages/x6/src/addon/selection/index.ts
+++ b/packages/x6/src/addon/selection/index.ts
@@ -125,7 +125,7 @@ export class Selection extends View<Selection.EventArgs> {
     options,
   }: Collection.EventArgs['node:change:position']) {
     const { showNodeSelectionBox, pointerEvents } = this.options
-    const { ui, selection } = options
+    const { ui, selection, translateBy } = options
     let allowTranslating = !this.translating
 
     /* Scenarios where this method is not called:
@@ -136,6 +136,9 @@ export class Selection extends View<Selection.EventArgs> {
       allowTranslating &&
       (showNodeSelectionBox !== true || pointerEvents === 'none')
     allowTranslating = allowTranslating && ui && !selection
+
+    // Avoid circular calls of child nodes
+    allowTranslating = allowTranslating && translateBy && node.id === translateBy
 
     if (allowTranslating) {
       this.translating = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixed the bug that node position was confused when the selection moved when selection.pointerEvents === 'none'
<!--- Describe your changes in detail -->

### Motivation and Context
若画布设置 selecting.pointerEvents 为 'none' ，选中画布中的部分节点，拖动选中节点时，若拖动的目标节点包含子节点，那么在拖动时其他节点的位置会错乱。如下图所示：

![x6](https://user-images.githubusercontent.com/31892817/172608987-17834946-09d0-4b3d-9681-9d9b6658c1d4.gif)

原因在于在判断是否 allowTranslating 时没有考虑子节点的情况，只通过 options 中是否含有 selection 属性来判断，而在 translateSelectedNodes 中也没有给子节点设置 selection，这样会导致每次拖动时，非子节点的 node 会因为子节点的 onNodePositionChanged 事件而再次 translate。

<img width="748" alt="image" src="https://user-images.githubusercontent.com/31892817/172611487-2da00d25-2863-4219-b8ac-fba154fb7741.png">

<img width="772" alt="image" src="https://user-images.githubusercontent.com/31892817/172610006-b9cac283-2523-474f-abd0-0098c1e93871.png">

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.