### PR TITLE
fix: 🐛 Fixed the bug that node moved when draging port #2216

### DIFF
--- a/packages/x6/src/view/node.ts
+++ b/packages/x6/src/view/node.ts
@@ -967,7 +967,8 @@ export class NodeView<
     this.setEventData<Partial<EventData.Magnet>>(e, {
       targetMagnet: magnet,
     })
-
+    // onMouseDown 需要阻止冒泡，解决 #2216
+    this.stopPropagation(e);
     if (graph.hook.validateMagnet(this, magnet, e)) {
       if (graph.options.magnetThreshold <= 0) {
         this.startConnectting(e, magnet, x, y)
@@ -976,7 +977,7 @@ export class NodeView<
       this.setEventData<Partial<EventData.Magnet>>(e, {
         action: 'magnet',
       })
-      this.stopPropagation(e)
+     
     } else {
       this.onMouseDown(e, x, y)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
bug : validateMagnet 返回false，拖拽port可以移动node 

原因：

在点击port 的时候，如果validateMagnet  返回false 时 执行 node 上 onMouseDown方法，因为没有阻止冒泡，所以触发了节点上的startNodeDragging 方法

![image](https://user-images.githubusercontent.com/37231473/175245265-7c3d2291-e0e9-44c9-8562-e2c10d9b07fd.png)


![image](https://user-images.githubusercontent.com/37231473/175244901-229bf611-0966-47b5-9d4b-7a9245d50275.png)




<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.