### PR TITLE
fix: 🐛 Fixed the bug that options.connecting.allowEdge does not take …

### DIFF
--- a/packages/x6/src/view/edge.ts
+++ b/packages/x6/src/view/edge.ts
@@ -2337,14 +2337,24 @@ export class EdgeView<
     data: EventData.ArrowheadDragging,
   ) {
     const graph = this.graph
-    const snap = graph.options.connecting.snap
-    const radius = (typeof snap === 'object' && snap.radius) || 50
-    const views = graph.renderer.findViewsInArea({
+    const { snap, allowEdge } = graph.options.connecting;
+    const radius = (typeof snap === 'object' && snap.radius) || 50;
+
+    const findViewsOption = {
       x: x - radius,
       y: y - radius,
       width: 2 * radius,
       height: 2 * radius,
-    })
+    };
+
+    const views = graph.renderer.findViewsInArea(findViewsOption);
+
+    if (allowEdge) {
+      const edgeViews = graph.renderer.findEdgeViewsInArea(findViewsOption).filter( view => {
+        return view != this;
+      });
+      views.push(...edgeViews);
+    }
 
     const prevView = data.closestView || null
     const prevMagnet = data.closestMagnet || null


### PR DESCRIPTION
…effect when options.connecting.snap is setting true (##2024)

<!--- Provide a general summary of your changes in the Title above -->

### Description

findViewsInArea 方法查只查 node ，所有要根据allowEdge是否开启使用，再使用findEdgeViewsInArea 查一次edge view


<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.