### PR TITLE
fix: 🐛 pick the max zindex node when frontOnly enabled in embending

### DIFF
--- a/packages/x6/src/util/array/array.ts
+++ b/packages/x6/src/util/array/array.ts
@@ -8,6 +8,7 @@ export {
   sortBy,
   groupBy,
   difference,
+  max,
 } from 'lodash-es'
 
 export * from './diff'

--- a/packages/x6/src/view/node.ts
+++ b/packages/x6/src/view/node.ts
@@ -835,7 +835,13 @@ export class NodeView<
 
     // Picks the node with the highest `z` index
     if (options.frontOnly) {
-      candidates = candidates.slice(-1)
+      if (candidates.length > 0) {
+        const zIndexMap = ArrayExt.groupBy(candidates, 'zIndex')
+        const maxZIndex = ArrayExt.max(Object.keys(zIndexMap))
+        if (maxZIndex) {
+          candidates = zIndexMap[maxZIndex]
+        }
+      }
     }
 
     // Filter the nodes which is invisiable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

pick the max zindex node when frontOnly enabled in embending

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.