### PR TITLE
feat: ✨ New property for edge connection attr

### DIFF
--- a/packages/x6/src/registry/attr/connection.ts
+++ b/packages/x6/src/registry/attr/connection.ts
@@ -9,24 +9,44 @@ export const connection: Attr.Definition = {
   qualify: isEdgeView,
   set(val, args) {
     const view = args.view as EdgeView
+    const reverse = ((val as any).reverse || false) as boolean
     const stubs = ((val as any).stubs || 0) as number
     let d
     if (Number.isFinite(stubs) && stubs !== 0) {
-      let offset
-      if (stubs < 0) {
-        const len = view.getConnectionLength() || 0
-        offset = (len + stubs) / 2
-      } else {
-        offset = stubs
-      }
-
-      const path = view.getConnection()
-      if (path) {
-        const sourceParts = path.divideAtLength(offset)
-        const targetParts = path.divideAtLength(-offset)
-        if (sourceParts && targetParts) {
-          d = `${sourceParts[0].serialize()} ${targetParts[1].serialize()}`
+      if (!reverse) {
+        let offset
+        if (stubs < 0) {
+          const len = view.getConnectionLength() || 0
+          offset = (len + stubs) / 2
+        } else {
+          offset = stubs
         }
+
+        const path = view.getConnection()
+        if (path) {
+          const sourceParts = path.divideAtLength(offset)
+          const targetParts = path.divideAtLength(-offset)
+          if (sourceParts && targetParts) {
+            d = `${sourceParts[0].serialize()} ${targetParts[1].serialize()}`
+          }
+        }
+      } else {
+        let offset
+        let length
+        const len = view.getConnectionLength() || 0
+        if (stubs < 0) {
+          offset = (len + stubs) / 2
+          length = -stubs
+        } else {
+          offset = stubs
+          length = len - stubs * 2
+        }
+
+        const path = view.getConnection()
+        d = path
+          ?.divideAtLength(offset)?.[1]
+          ?.divideAtLength(length)?.[0]
+          ?.serialize()
       }
     }
 

--- a/sites/x6-sites/docs/api/registry/attr.en.md
+++ b/sites/x6-sites/docs/api/registry/attr.en.md
@@ -463,14 +463,19 @@ edge.attr('pathSelector', {
 })
 ```
 
-也支持包含 `stubs` 选项的对象。
+也支持包含 `stubs` 和 `reserve` 选项的对象。
 
-- 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `nnection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
-- 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `nnection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
+- 当 `reverse` 为 `false` 时：
+  - 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `nnection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
+  - 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `nnection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
+
+- 当 `reverse` 为 `true` 时：
+  - 当 `stubs` 为正数时，起始和终止部分不渲染的长度。例如 `nnection: { stubs: 20 }` 表示起始的 `20px` 和终止的 `20px` 不渲染。
+  - 当 `stubs` 为负数时，表示中间部分的长度。例如 `nnection: { stubs: -20 }` 表示只渲染中间 `20px`。
 
 ```ts
 edge.attr('pathSelector', { 
-  connection: { stubs: -20 },
+  connection: { stubs: -20, reverse: true },
 })
 ```
 

--- a/sites/x6-sites/docs/api/registry/attr.en.md
+++ b/sites/x6-sites/docs/api/registry/attr.en.md
@@ -466,12 +466,12 @@ edge.attr('pathSelector', {
 也支持包含 `stubs` 和 `reserve` 选项的对象。
 
 - 当 `reverse` 为 `false` 时：
-  - 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `nnection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
-  - 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `nnection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
+  - 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `connection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
+  - 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `connection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
 
 - 当 `reverse` 为 `true` 时：
-  - 当 `stubs` 为正数时，起始和终止部分不渲染的长度。例如 `nnection: { stubs: 20 }` 表示起始的 `20px` 和终止的 `20px` 不渲染。
-  - 当 `stubs` 为负数时，表示中间部分的长度。例如 `nnection: { stubs: -20 }` 表示只渲染中间 `20px`。
+  - 当 `stubs` 为正数时，起始和终止部分不渲染的长度。例如 `connection: { stubs: 20 }` 表示起始的 `20px` 和终止的 `20px` 不渲染。
+  - 当 `stubs` 为负数时，表示中间部分的长度。例如 `connection: { stubs: -20 }` 表示只渲染中间 `20px`。
 
 ```ts
 edge.attr('pathSelector', { 

--- a/sites/x6-sites/docs/api/registry/attr.zh.md
+++ b/sites/x6-sites/docs/api/registry/attr.zh.md
@@ -463,14 +463,19 @@ edge.attr('pathSelector', {
 })
 ```
 
-也支持包含 `stubs` 选项的对象。
+也支持包含 `stubs` 和 `reserve` 选项的对象。
 
-- 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `nnection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
-- 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `nnection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
+- 当 `reverse` 为 `false` 时：
+  - 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `nnection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
+  - 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `nnection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
+
+- 当 `reverse` 为 `true` 时：
+  - 当 `stubs` 为正数时，起始和终止部分不渲染的长度。例如 `nnection: { stubs: 20 }` 表示起始的 `20px` 和终止的 `20px` 不渲染。
+  - 当 `stubs` 为负数时，表示中间部分的长度。例如 `nnection: { stubs: -20 }` 表示只渲染中间 `20px`。
 
 ```ts
 edge.attr('pathSelector', { 
-  connection: { stubs: -20 },
+  connection: { stubs: -20, reverse: true },
 })
 ```
 

--- a/sites/x6-sites/docs/api/registry/attr.zh.md
+++ b/sites/x6-sites/docs/api/registry/attr.zh.md
@@ -466,12 +466,12 @@ edge.attr('pathSelector', {
 也支持包含 `stubs` 和 `reserve` 选项的对象。
 
 - 当 `reverse` 为 `false` 时：
-  - 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `nnection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
-  - 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `nnection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
+  - 当 `stubs` 为正数时，表示渲染的起始和终止部分长度。例如 `connection: { stubs: 20 }` 表示连线只渲染起始的 `20px` 和终止的 `20px`，其余部分不渲染。
+  - 当 `stubs` 为负数时，表示中间缺失（不渲染）部分的长度。例如 `connection: { stubs: -20 }` 表示连线中间有 `20px` 不渲染。
 
 - 当 `reverse` 为 `true` 时：
-  - 当 `stubs` 为正数时，起始和终止部分不渲染的长度。例如 `nnection: { stubs: 20 }` 表示起始的 `20px` 和终止的 `20px` 不渲染。
-  - 当 `stubs` 为负数时，表示中间部分的长度。例如 `nnection: { stubs: -20 }` 表示只渲染中间 `20px`。
+  - 当 `stubs` 为正数时，起始和终止部分不渲染的长度。例如 `connection: { stubs: 20 }` 表示起始的 `20px` 和终止的 `20px` 不渲染。
+  - 当 `stubs` 为负数时，表示中间部分的长度。例如 `connection: { stubs: -20 }` 表示只渲染中间 `20px`。
 
 ```ts
 edge.attr('pathSelector', { 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

X6 目前为 <path> 提供了 connection 的一个属性，可通过此方法渲染path的两边。
https://x6.antv.vision/zh/docs/api/registry/attr#connection

<img width="825" alt="image" src="https://user-images.githubusercontent.com/4632277/179210742-209854d6-2bf4-4214-b1e1-755f17581e31.png">

但是我想渲染相反的地方，只渲染中间

<img width="806" alt="image" src="https://user-images.githubusercontent.com/4632277/179211018-b8b4c859-905f-4112-a783-591404dd5152.png">

```js
edge.attr('pathSelector', {
  connection: { stubs: 40, reverse: true },
  stroke: 'red',
  fill: 'none',
})
```

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.