### PR TITLE
fix(history): 🐛 try to merge move+embed into 1 undo

### DIFF
--- a/examples/x6-example-features/src/pages/undo/index.tsx
+++ b/examples/x6-example-features/src/pages/undo/index.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
 import { Button } from 'antd'
+import React from 'react'
+
 import { Graph } from '@antv/x6'
+
 import '../index.less'
 
 export default class Example extends React.Component<
@@ -22,10 +24,13 @@ export default class Example extends React.Component<
       height: 600,
       grid: true,
       history: true,
+      embedding: {
+        enabled: true,
+      },
     })
 
     this.history = graph.history
-    this.history.on('change', () => {
+    this.history.on('change', (info) => {
       this.setState({
         canRedo: this.history.canRedo(),
         canUndo: this.history.canUndo(),
@@ -55,6 +60,21 @@ export default class Example extends React.Component<
       attrs: {
         label: {
           text: 'World',
+        },
+        body: {
+          strokeWidth: 1,
+        },
+      },
+    })
+
+    graph.addNode({
+      x: 400,
+      y: 100,
+      width: 150,
+      height: 150,
+      attrs: {
+        label: {
+          text: '🌎',
         },
         body: {
           strokeWidth: 1,

--- a/packages/x6/src/view/node.ts
+++ b/packages/x6/src/view/node.ts
@@ -612,6 +612,13 @@ export class NodeView<
   }
 
   notifyMouseUp(e: JQuery.MouseUpEvent, x: number, y: number) {
+    // Problem: super will call stopBatch before event listeners
+    // attached to this **node** run. Those events will not count
+    // towards this batch, despite being triggered by the same UI event.
+    //
+    // This complicates a lot of stuff e.g. history recording.
+    //
+    // See https://github.com/antvis/X6/issues/2421 for background.
     super.onMouseUp(e, x, y)
     this.notify('node:mouseup', this.getEventArgs(e, x, y))
   }
@@ -907,6 +914,7 @@ export class NodeView<
   }
 
   finalizeEmbedding(e: JQuery.MouseUpEvent, data: EventData.MovingTargetNode) {
+    this.graph.startBatch('embedding')
     const cell = data.cell || this.cell
     const graph = data.graph || this.graph
     const view = graph.findViewByCell(cell)
@@ -940,6 +948,7 @@ export class NodeView<
         currentParent: cell.getParent(),
       })
     }
+    this.graph.stopBatch('embedding')
   }
 
   getDelegatedView() {


### PR DESCRIPTION
### Description

Patches incorrect behaviors pertaining to undo/redo a "drag + embed" combo.

Closes #2421

### Motivation and Context

Current version of `History` treats a "node dragging" interaction followed by an "embedding" interaction as three separate actions, meaning that it would take 3 undo's to fully revert the canvas to a previous state i.e. revert the moved node to its previous position — even though from the user's perspective, this really all happens in one dragging motion, **thus users would expect the dragging to be undone by invoking undo just once.**

To provide this expected behavior, this fix patches the `history` addon such that this specific interaction would be merged under the hood.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.