### PR TITLE
fix: arrowhead not get options bug

### DIFF
--- a/packages/x6/src/registry/tool/arrowhead.ts
+++ b/packages/x6/src/registry/tool/arrowhead.ts
@@ -74,6 +74,7 @@ class Arrowhead extends ToolsView.ToolItem<EdgeView, Arrowhead.Options> {
         x: coords.x,
         y: coords.y,
         options: {
+          ...this.options,
           toolId: this.cid,
         },
       })


### PR DESCRIPTION
https://github.com/antvis/X6/issues/3064


### Describe the bug


比如我想在箭头上这么定义,加上一个**fallbackAction: "remove"**,好让箭头在拖到空白的地方,能被移除掉,而不是象现在这样,自动还原
![image](https://user-images.githubusercontent.com/361781/208379270-7f8dd2b7-fdbc-47e0-a399-b6ccd024e3c9.png)


建议这么修改一下这里,以解决这个问题
[/packages/x6/src/registry/tool/arrowhead.ts#L54-L55](https://github.com/antvis/X6/blob/master/packages/x6/src/registry/tool/arrowhead.ts#L54-L55)
![image](https://user-images.githubusercontent.com/361781/208378718-9aa980e7-b21f-480e-a46f-aff604c37162.png)


### Your Example Website or App

https://github.com/antvis/X6/blob/master/packages/x6/src/registry/tool/arrowhead.ts#L54-L55

### Steps to Reproduce the Bug or Issue

```
 cell.addTools([
          {
            name: "target-arrowhead",
            args: {
              fallbackAction: "remove",
            },
          },
        ]);
```

### Expected behavior

在箭头拖到空白的地方,能被移除掉,而不是象现在这样,自动还原

### Screenshots or Videos

_No response_

### Platform

- OS: [e.g. macOS, Windows, Linux]
- Browser: [e.g. Chrome, Safari, Firefox]
- Version: [e.g. 91.1]


### Additional context

_No response_