### PR TITLE
chore: add lodash into peerDependencies

### DIFF
--- a/packages/x6-common/package.json
+++ b/packages/x6-common/package.json
@@ -36,8 +36,10 @@
     "coveralls": "rss",
     "pretest": "rss"
   },
+  "peerDependencies": {
+    "lodash-es": "^4.17.15"
+  },
   "dependencies": {
-    "lodash-es": "^4.17.15",
     "utility-types": "^3.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

新建Angular项目, 安装antv2.3.0报如下错误
![图片](https://user-images.githubusercontent.com/30228406/218997526-91f2756b-8b89-4d64-a615-22256672524e.png)
必须安装的第三方依赖应该放在`peerDependencies`当中.

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [x] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.