### PR TITLE
fix(tool): 修复 node-editor 在 edge 上使用时，会出现 label 位置错乱和丢失问题

### DIFF
--- a/examples/x6-example-features/src/pages/index.tsx
+++ b/examples/x6-example-features/src/pages/index.tsx
@@ -104,6 +104,10 @@ const dataSource = [
     example: 'tools/clean',
     description: '常用工具',
   },
+  {
+    example: 'tools/node-editor',
+    description: '文本编辑工具',
+  },
   // case
   {
     example: 'case/bpmn',

--- a/examples/x6-example-features/src/pages/tools/node-editor.tsx
+++ b/examples/x6-example-features/src/pages/tools/node-editor.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { Graph } from '@antv/x6'
+import '../index.less'
+
+export default class Example extends React.Component {
+  private container: HTMLDivElement
+
+  componentDidMount() {
+    const graph = new Graph({
+      container: this.container,
+      width: 800,
+      height: 600,
+      grid: true,
+    })
+
+    graph.on('cell:dblclick', ({ cell, e }) => {
+      const isNode = cell.isNode()
+      const name = cell.isNode() ? 'node-editor' : 'edge-editor'
+      cell.removeTool(name)
+      cell.addTools({
+        name,
+        args: {
+          event: e,
+          attrs: {
+            backgroundColor: isNode ? '#EFF4FF' : '#FFF',
+          },
+        },
+      })
+    })
+
+    const source = graph.addNode({
+      x: 180,
+      y: 60,
+      width: 100,
+      height: 40,
+      attrs: {
+        body: {
+          stroke: '#5F95FF',
+          fill: '#EFF4FF',
+          strokeWidth: 1,
+        },
+      },
+      ports: {
+        groups: {
+          bottom: {
+            position: 'bottom',
+            attrs: {
+              circle: {
+                stroke: '#5F95FF',
+                strokeWidth: 1,
+                r: 4,
+              },
+            },
+          },
+        },
+        items: [
+          {
+            id: 'port-1',
+            group: 'bottom',
+            tip: 'port-1-tip',
+          },
+        ],
+      },
+    })
+
+    const target = graph.addNode({
+      x: 320,
+      y: 250,
+      width: 100,
+      height: 40,
+      attrs: {
+        body: {
+          stroke: '#5F95FF',
+          fill: '#EFF4FF',
+          strokeWidth: 1,
+        },
+      },
+      ports: {
+        groups: {
+          top: {
+            position: 'top',
+            attrs: {
+              circle: {
+                stroke: '#5F95FF',
+                strokeWidth: 1,
+                r: 4,
+              },
+            },
+          },
+        },
+        items: [
+          {
+            id: 'port-2',
+            group: 'top',
+            tip: 'port-2-tip',
+          },
+        ],
+      },
+    })
+
+    graph.addEdge({
+      source: { cell: source, port: 'port-1' },
+      target: { cell: target, port: 'port-2' },
+      attrs: {
+        line: {
+          stroke: '#A2B1C3',
+          strokeWidth: 2,
+        },
+      },
+      zIndex: -1,
+    })
+  }
+
+  refContainer = (container: HTMLDivElement) => {
+    this.container = container
+  }
+
+  render() {
+    return (
+      <div className="x6-graph-wrap">
+        <div ref={this.refContainer} className="x6-graph" />
+      </div>
+    )
+  }
+}

--- a/packages/x6/src/registry/tool/editor.ts
+++ b/packages/x6/src/registry/tool/editor.ts
@@ -223,6 +223,7 @@ export namespace CellEditor {
       return cell.prop(`labels/${index}/attrs/label/text`)
     },
     setText({ cell, value, index, distance }) {
+      if (!value) return
       const edge = cell as Edge
       if (index === -1) {
         edge.appendLabel({

--- a/packages/x6/src/registry/tool/editor.ts
+++ b/packages/x6/src/registry/tool/editor.ts
@@ -57,6 +57,9 @@ export class CellEditor extends ToolsView.ToolItem<
         const { translation } = Dom.parseTransformString(matrix)
         pos = new Point(translation.tx, translation.ty)
         minWidth = Util.getBBox(target).width
+        // hide display value when editing state because of character ghosting.
+        cell.setPropByPath(`labels/${index}/attrs/rect/visibility`, 'hidden')
+        cell.setPropByPath(`labels/${index}/attrs/text/visibility`, 'hidden')
       } else {
         if (!this.options.labelAddable) {
           return this
@@ -95,7 +98,9 @@ export class CellEditor extends ToolsView.ToolItem<
     editor.innerText = text || ''
 
     // clear display value when edit status because char ghosting.
-    this.setCellText('')
+    if (cell.isNode()) {
+      this.setCellText('')
+    }
 
     return this
   }
@@ -223,7 +228,6 @@ export namespace CellEditor {
       return cell.prop(`labels/${index}/attrs/label/text`)
     },
     setText({ cell, value, index, distance }) {
-      if (!value) return
       const edge = cell as Edge
       if (index === -1) {
         edge.appendLabel({
@@ -239,6 +243,9 @@ export namespace CellEditor {
       } else {
         if (value) {
           edge.prop(`labels/${index}/attrs/label/text`, value)
+          // display the label after the modification is complete.
+          cell.removeProp(`labels/${index}/attrs/rect/visibility`)
+          cell.removeProp(`labels/${index}/attrs/text/visibility`)
         } else if (typeof index === 'number') {
           edge.removeLabelAt(index)
         }


### PR DESCRIPTION
### 问题描述
修复 node-editor 在 edge 上使用时，会重复添加多个空 label，并且修改 label 时会导致 label 位置错乱和丢失的问题。  

### 重现链接
https://x6.antv.antgroup.com/examples/node/tool#editable  

### 重现步骤  
1. 点击 edge 添加 label 1，此时对应的 svg 节点下会出现两个 label 其中一个是空的。  
2. 修改 label 1，点击外部区域，确认修改后，label1 会消失。  

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.