### PR TITLE
fix: cannot be invoked without new

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "target": "es5",
+    "target": "es6",
     "lib": ["DOM", "ES2020"]
   }
 }


### PR DESCRIPTION
fix Class constructor xx cannot be invoked without 'new'

### Description

Uncaught TypeError: Class constructor Mh cannot be invoked without 'new'

### Motivation and Context

https://github.com/antvis/X6/issues/3270

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 