### PR TITLE
docs(v1-react): fix memo equal condition

### DIFF
--- a/sites/x6-sites/docs/tutorial/advanced/react.en.md
+++ b/sites/x6-sites/docs/tutorial/advanced/react.en.md
@@ -185,7 +185,7 @@ export const MyComponent = memo(
     return // ...
   },
   (prev, next) => {
-    return Boolean(next.node?.hasChanged('data'))
+    return !next.node?.hasChanged('data')
   },
 )
 ```

--- a/sites/x6-sites/docs/tutorial/advanced/react.zh.md
+++ b/sites/x6-sites/docs/tutorial/advanced/react.zh.md
@@ -183,7 +183,7 @@ export const MyComponent = memo(
     return // ...
   },
   (prev, next) => {
-    return Boolean(next.node?.hasChanged('data'))
+    return !next.node?.hasChanged('data')
   },
 )
 ```


### PR DESCRIPTION
此 PR 修复了 v1 文档中存在的一个谬误：

`React.memo` 接受的第二个参数 `propsAreEqual `为 `true` 时，则认为数据没有发生改变，不会重新渲染，反之会重新渲染。

当节点的数据没有发生改变时，`next.node?.hasChanged('data')` 的结果为 `false`，应该取一次 `!` 而不是直接转为 Bool 值。