### PR TITLE
docs: 补充 view:mounted 和 view:unmounted 文档

### DIFF
--- a/sites/x6-sites/docs/tutorial/basic/events.zh.md
+++ b/sites/x6-sites/docs/tutorial/basic/events.zh.md
@@ -389,3 +389,18 @@ graph.on("edge:transition:complete", (args: Animation.CallbackArgs) => {});
 graph.on("edge:transition:stop", (args: Animation.StopArgs) => {});
 graph.on("edge:transition:finish", (args: Animation.CallbackArgs) => {});
 ```
+
+
+## 视图
+
+由于X6实现了异步的渲染调度算法，所以节点的添加不一定意味着挂载到画布上。节点在被挂载到画布时以及从画布上卸载时会分别触发单独的事件。
+
+| 事件名           | 回调参数                    | 说明                          |
+| ---------------- | ----------------------- | ------------------------------ |
+| `view:mounted` | `{ view: CellView }` | 节点被挂载到画布上时触发。    |
+| `view:unmounted` | `{ view: CellView }` | 节点从画布上卸载时触发。  |
+
+```ts
+graph.on("view:mounted", ({ view }) => {});
+graph.on("view:unmounted", ({ view }) => {});
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
补充 view:mounted 和 view:unmounted 文档

### Description

补充 view:mounted 和 view:unmounted 文档
closes https://github.com/antvis/X6/issues/3374
<!--- Describe your changes in detail -->

### Motivation and Context

新增了view:mounted和view:unmounted事件，文档同步更新
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [x] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.