### PR TITLE
careless mistake fix of docs

### DIFF
--- a/sites/x6-sites/docs/tutorial/plugins/transform.zh.md
+++ b/sites/x6-sites/docs/tutorial/plugins/transform.zh.md
@@ -87,7 +87,7 @@ graph.use(
 new Transform({
   resizing: {
     enabled: true,
-    orthogonal(ndoe: Node) {
+    orthogonal(node: Node) {
       const { enableOrthogonal } = node.getData();
       return enableOrthogonal;
     },


### PR DESCRIPTION
In the websites: "https://x6.antv.antgroup.com/tutorial/plugins/transform#api", sample code has careless mistake
```ts
new Transform({
  resizing: {
    enabled: true,
    orthogonal(ndoe: Node) { //'ndoe' to 'node'
      const { enableOrthogonal } = node.getData();
      return enableOrthogonal;
    },
  },
});
```