### PR TITLE
fix: correct router path

### DIFF
--- a/sites/x6-sites/.dumirc.ts
+++ b/sites/x6-sites/.dumirc.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     },
     navs: [
       {
-        slug: 'docs/tutorial/about',
+        slug: 'tutorial/about',
         title: {
           zh: '文档',
           en: 'Tutorials',
@@ -35,7 +35,7 @@ export default defineConfig({
         order: 0,
       },
       {
-        slug: 'docs/api/graph',
+        slug: 'api/graph/graph',
         title: {
           zh: 'API',
           en: 'API',


### PR DESCRIPTION
problems: 
- Right-click on navigator link and select "New Tab" in context menu.
- 404 error page opened in new tab

router path will auto corrected while left-click on nav link <a>, while cannot be corrected by open in new tab.
