### PR TITLE
fix($stencil): compact mode Cannot add odd nodes in mode

### DIFF
--- a/packages/x6-plugin-stencil/src/grid.ts
+++ b/packages/x6-plugin-stencil/src/grid.ts
@@ -124,7 +124,10 @@ namespace GridLayout {
   }
 
   export function getMaxDim(nodes: Node[], name: 'width' | 'height') {
-    return nodes.reduce((memo, node) => Math.max(node.getSize()[name], memo), 0)
+    return nodes.reduce(
+      (memo, node) => Math.max(node?.getSize()[name], memo),
+      0,
+    )
   }
 
   export function getNodesInRow(
@@ -134,7 +137,7 @@ namespace GridLayout {
   ) {
     const res: Node[] = []
     for (let i = columnCount * rowIndex, ii = i + columnCount; i < ii; i += 1) {
-      res.push(nodes[i])
+      if (nodes[i]) res.push(nodes[i])
     }
     return res
   }
@@ -146,7 +149,7 @@ namespace GridLayout {
   ) {
     const res: Node[] = []
     for (let i = columnIndex, ii = nodes.length; i < ii; i += columnCount) {
-      res.push(nodes[i])
+      if (nodes[i]) res.push(nodes[i])
     }
     return res
   }


### PR DESCRIPTION
Add null check when node getSize()
add check valid node in function getNodesInRow/Column

Closes #3535

<!--- Provide a general summary of your changes in the Title above -->

### Description

Add null check when node getSize() and add validation check for valid node when retrieving a node by function getNodesInRow、getNodesInColumn

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.