### PR TITLE
feat: ✨ add `graph:scroll` event for `scroller` plugin

### DIFF
--- a/packages/x6-plugin-scroller/src/api.ts
+++ b/packages/x6-plugin-scroller/src/api.ts
@@ -1,5 +1,6 @@
 import { Graph } from '@antv/x6'
 import { Scroller } from './index'
+import { ScrollerImpl } from './scroller'
 
 declare module '@antv/x6/lib/graph/graph' {
   interface Graph {
@@ -13,7 +14,7 @@ declare module '@antv/x6/lib/graph/graph' {
 
 declare module '@antv/x6/lib/graph/events' {
   interface EventArgs {
-    'graph:scroll': { container: HTMLDivElement }
+    'graph:scroll': { e: ScrollerImpl.ScrollEvent }
   }
 }
 

--- a/packages/x6-plugin-scroller/src/api.ts
+++ b/packages/x6-plugin-scroller/src/api.ts
@@ -9,6 +9,9 @@ declare module '@antv/x6/lib/graph/graph' {
     getScrollbarPosition: () => { left: number; top: number }
     setScrollbarPosition: (left?: number, top?: number) => Graph
   }
+  interface EventArgs {
+    'graph:scroll': { scrollLeft: number; scrollTop: number }
+  }
 }
 
 Graph.prototype.lockScroller = function () {

--- a/packages/x6-plugin-scroller/src/api.ts
+++ b/packages/x6-plugin-scroller/src/api.ts
@@ -9,8 +9,11 @@ declare module '@antv/x6/lib/graph/graph' {
     getScrollbarPosition: () => { left: number; top: number }
     setScrollbarPosition: (left?: number, top?: number) => Graph
   }
+}
+
+declare module '@antv/x6/lib/graph/events' {
   interface EventArgs {
-    'graph:scroll': { scrollLeft: number; scrollTop: number }
+    'graph:scroll': { container: HTMLDivElement }
   }
 }
 

--- a/packages/x6-plugin-scroller/src/scroller.ts
+++ b/packages/x6-plugin-scroller/src/scroller.ts
@@ -130,12 +130,11 @@ export class ScrollerImpl extends View<ScrollerImpl.EventArgs> {
     model.on('cell:changed', this.onUpdate, this)
 
     Dom.Event.on(this.container, 'scroll', () => {
-      this.trigger('graph:scroll', {
-        e: {
-          scrollLeft: this.container.scrollLeft,
-          scrollTop: this.container.scrollTop,
-        },
-      })
+      const e = {
+        scrollLeft: this.container.scrollLeft,
+        scrollTop: this.container.scrollTop,
+      }
+      this.notify('graph:scroll', { e })
     })
 
     this.delegateBackgroundEvents()

--- a/packages/x6-plugin-scroller/src/scroller.ts
+++ b/packages/x6-plugin-scroller/src/scroller.ts
@@ -129,6 +129,10 @@ export class ScrollerImpl extends View<ScrollerImpl.EventArgs> {
     model.on('cell:removed', this.onUpdate, this)
     model.on('cell:changed', this.onUpdate, this)
 
+    this.container.addEventListener('scroll', () => {
+      this.trigger('graph:scroll', { container: this.container })
+    })
+
     this.delegateBackgroundEvents()
   }
 
@@ -249,10 +253,6 @@ export class ScrollerImpl extends View<ScrollerImpl.EventArgs> {
   protected storeScrollPosition() {
     this.cachedScrollLeft = this.container.scrollLeft
     this.cachedScrollTop = this.container.scrollTop
-    this.trigger('graph:scroll', {
-      scrollLeft: this.container.scrollLeft,
-      scrollTop: this.container.scrollTop,
-    })
   }
 
   protected restoreScrollPosition() {
@@ -1119,6 +1119,14 @@ export class ScrollerImpl extends View<ScrollerImpl.EventArgs> {
     this.stopListening()
   }
 
+  protected notify<K extends keyof ScrollerImpl.EventArgs>(
+    name: K,
+    args: ScrollerImpl.EventArgs[K],
+  ) {
+    this.trigger(name, args)
+    this.graph.trigger(name, args)
+  }
+
   @View.dispose()
   dispose() {
     Dom.before(this.container, this.graph.container)
@@ -1131,7 +1139,7 @@ export namespace ScrollerImpl {
     'pan:start': { e: Dom.MouseDownEvent }
     panning: { e: Dom.MouseMoveEvent }
     'pan:stop': { e: Dom.MouseUpEvent }
-    'graph:scroll': { e: { scrollLeft: number; scrollTop: number } }
+    'graph:scroll': { container: HTMLDivElement }
   }
   export interface Options {
     graph: Graph

--- a/packages/x6-plugin-scroller/src/scroller.ts
+++ b/packages/x6-plugin-scroller/src/scroller.ts
@@ -249,6 +249,10 @@ export class ScrollerImpl extends View<ScrollerImpl.EventArgs> {
   protected storeScrollPosition() {
     this.cachedScrollLeft = this.container.scrollLeft
     this.cachedScrollTop = this.container.scrollTop
+    this.trigger('graph:scroll', {
+      scrollLeft: this.container.scrollLeft,
+      scrollTop: this.container.scrollTop,
+    })
   }
 
   protected restoreScrollPosition() {
@@ -1127,6 +1131,7 @@ export namespace ScrollerImpl {
     'pan:start': { e: Dom.MouseDownEvent }
     panning: { e: Dom.MouseMoveEvent }
     'pan:stop': { e: Dom.MouseUpEvent }
+    'graph:scroll': { e: { scrollLeft: number; scrollTop: number } }
   }
   export interface Options {
     graph: Graph

--- a/packages/x6-plugin-scroller/src/scroller.ts
+++ b/packages/x6-plugin-scroller/src/scroller.ts
@@ -129,8 +129,13 @@ export class ScrollerImpl extends View<ScrollerImpl.EventArgs> {
     model.on('cell:removed', this.onUpdate, this)
     model.on('cell:changed', this.onUpdate, this)
 
-    this.container.addEventListener('scroll', () => {
-      this.trigger('graph:scroll', { container: this.container })
+    Dom.Event.on(this.container, 'scroll', () => {
+      this.trigger('graph:scroll', {
+        e: {
+          scrollLeft: this.container.scrollLeft,
+          scrollTop: this.container.scrollTop,
+        },
+      })
     })
 
     this.delegateBackgroundEvents()
@@ -1139,7 +1144,12 @@ export namespace ScrollerImpl {
     'pan:start': { e: Dom.MouseDownEvent }
     panning: { e: Dom.MouseMoveEvent }
     'pan:stop': { e: Dom.MouseUpEvent }
-    'graph:scroll': { container: HTMLDivElement }
+    'graph:scroll': { e: ScrollEvent }
+  }
+
+  export interface ScrollEvent {
+    scrollLeft: number
+    scrollTop: number
   }
   export interface Options {
     graph: Graph


### PR DESCRIPTION
feat: ✨ add `graph:scroll` event for `scroller` plugin

### Description

为 `x6-plugin-scroller`  插件提供了新的事件 `graph:scroll` 支持

### Motivation and Context

- 目前 `x6-plugin-scroller` 插件没有提供任何可用的事件， `graph` 在滚动的时候，可以通过 `graph:scroll` 事件执行一系列操作

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.