### PR TITLE
feat: x6-vue-shape supports getting nodes and graph in the props 

### DIFF
--- a/packages/x6-vue-shape/src/teleport.ts
+++ b/packages/x6-vue-shape/src/teleport.ts
@@ -16,7 +16,7 @@ export function connect(
     const { Teleport, markRaw } = Vue as any
     items[id] = markRaw(
       defineComponent({
-        render: () => h(Teleport, { to: container } as any, [h(component)]),
+        render: () => h(Teleport, { to: container } as any, [h(component, { getNode: () => node, getGraph: () => graph })]),
         provide: () => ({
           getNode: () => node,
           getGraph: () => graph,

--- a/packages/x6-vue-shape/src/teleport.ts
+++ b/packages/x6-vue-shape/src/teleport.ts
@@ -16,7 +16,7 @@ export function connect(
     const { Teleport, markRaw } = Vue as any
     items[id] = markRaw(
       defineComponent({
-        render: () => h(Teleport, { to: container } as any, [h(component, { getNode: () => node, getGraph: () => graph })]),
+        render: () => h(Teleport, { to: container } as any, [h(component, { node, graph })]),
         provide: () => ({
           getNode: () => node,
           getGraph: () => graph,

--- a/packages/x6-vue-shape/src/view.ts
+++ b/packages/x6-vue-shape/src/view.ts
@@ -31,19 +31,17 @@ export class VueShapeView extends NodeView<VueShape> {
     if (root) {
       const { component } = shapeMaps[node.shape]
       if (component) {
-        const getNode = () => node
-        const getGraph = () => graph
         if (isVue2) {
           const Vue = Vue2 as any
           this.vm = new Vue({
             el: root,
             render(h: any) {
-              return h(component, { getNode, getGraph })
+              return h(component, { node, graph })
             },
             provide() {
               return {
-                getNode,
-                getGraph,
+                getNode: () => node,
+                getGraph: () => graph,
               }
             },
           })
@@ -53,12 +51,12 @@ export class VueShapeView extends NodeView<VueShape> {
           } else {
             this.vm = createApp({
               render() {
-                return h(component, { getNode, getGraph })
+                return h(component, { node, graph })
               },
               provide() {
                 return {
-                  getNode,
-                  getGraph,
+                  getNode: () => node,
+                  getGraph: () => graph,
                 }
               },
             })

--- a/packages/x6-vue-shape/src/view.ts
+++ b/packages/x6-vue-shape/src/view.ts
@@ -31,17 +31,19 @@ export class VueShapeView extends NodeView<VueShape> {
     if (root) {
       const { component } = shapeMaps[node.shape]
       if (component) {
+        const getNode = () => node
+        const getGraph = () => graph
         if (isVue2) {
           const Vue = Vue2 as any
           this.vm = new Vue({
             el: root,
             render(h: any) {
-              return h(component)
+              return h(component, { getNode, getGraph })
             },
             provide() {
               return {
-                getNode: () => node,
-                getGraph: () => graph,
+                getNode,
+                getGraph,
               }
             },
           })
@@ -51,12 +53,12 @@ export class VueShapeView extends NodeView<VueShape> {
           } else {
             this.vm = createApp({
               render() {
-                return h(component)
+                return h(component, { getNode, getGraph })
               },
               provide() {
                 return {
-                  getNode: () => node,
-                  getGraph: () => graph,
+                  getNode,
+                  getGraph,
                 }
               },
             })


### PR DESCRIPTION
This change does not affect the original usage, and provides a new way to getting nodes and graph.

<!--- Provide a general summary of your changes in the Title above -->

### Description
This change does not affect the original usage, and provides a new way to getting nodes and graph.
<!--- Describe your changes in detail -->

### Motivation and Context
参考 #3756，由于只提供provide的方式在webpack模块联邦打包后，存在问题，导致inject上下文获取不到，通过h渲染子组件时传入props的方式就能保证子组件能获取到对应方法。这个改动并不影响原有使用，相当于提供了一个新的方式。

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
