### PR TITLE
docs: wobble parameter names are incorrect

### DIFF
--- a/sites/x6-sites/docs/api/registry/connector.zh.md
+++ b/sites/x6-sites/docs/api/registry/connector.zh.md
@@ -197,7 +197,7 @@ export interface WobbleArgs {
 function wobble(
   sourcePoint: Point.PointLike,
   targetPoint: Point.PointLike,
-  routePoints: Point.PointLike[],
+  vertices: Point.PointLike[],
   args: WobbleArgs,
 ) {
   const spread = args.spread || 20


### PR DESCRIPTION
wobble 函数参数的名字与函数体用的不一致