### PR TITLE
docs: cell.setData, `deep: false` code error

### DIFF
--- a/sites/x6-sites/docs/api/model/cell.zh.md
+++ b/sites/x6-sites/docs/api/model/cell.zh.md
@@ -1357,7 +1357,7 @@ cell.setData(data, { overwrite: true })
 当 `options.deep` 为 `false` 时，与原数据进行浅 merge：
 
 ```ts
-cell.setData(data, { overwrite: true })
+cell.setData(data, { deep: false })
 ```
 
 :::info{title=提示}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

https://x6.antv.vision/zh/docs/api/model/cell/#setdata 中，出现了两次 { overwrite: true }，第二个应该是 { deep: true }。

当 options.overwrite 为 true 时，替换旧数据：

```
cell.setData(data, { overwrite: true })
```

当 options.deep 为 false 时，与原数据进行浅 merge：

```
cell.setData(data, { overwrite: true })
```

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [x] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
