### PR TITLE
fix: plugin-selection edge selection when moving

### DIFF
--- a/examples/x6-example-features/src/pages/selection/index.tsx
+++ b/examples/x6-example-features/src/pages/selection/index.tsx
@@ -21,6 +21,7 @@ export default class Example extends React.Component {
       multiple: true,
       strict: true,
       showNodeSelectionBox: true,
+      showEdgeSelectionBox: true,
       selectCellOnMoved: false,
       filter(cell) {
         return cell !== a

--- a/packages/x6-plugin-selection/src/selection.ts
+++ b/packages/x6-plugin-selection/src/selection.ts
@@ -76,6 +76,7 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
 
     graph.on('scale', this.onGraphTransformed, this)
     graph.on('translate', this.onGraphTransformed, this)
+    graph.on('node:moving', this.onNodeOrEdgeMove, this)
     graph.model.on('updated', this.onModelUpdated, this)
 
     collection.on('added', this.onCellAdded, this)
@@ -113,6 +114,10 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
   }
 
   protected onCellChanged() {
+    this.updateSelectionBoxes()
+  }
+
+  protected onNodeOrEdgeMove() {
     this.updateSelectionBoxes()
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->
When set `showEdgeSelectionBox` to `true`, moving node the edge selection do not update.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->
bugfix https://github.com/antvis/X6/issues/3084

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
