### PR TITLE
fix: stencil addGroup

### DIFF
--- a/examples/x6-example-features/src/pages/stencil/index.tsx
+++ b/examples/x6-example-features/src/pages/stencil/index.tsx
@@ -111,6 +111,8 @@ export default class Example extends React.Component {
 
     stencil.load([r, c, c2, r2.clone()], 'group1')
     stencil.load([c2.clone(), r2, r3, c3], 'group2')
+    stencil.addGroup({ name: 'group3' })
+    stencil.load([c2.clone()], 'group3')
   }
 
   refContainer = (container: HTMLDivElement) => {

--- a/packages/x6-plugin-stencil/src/index.ts
+++ b/packages/x6-plugin-stencil/src/index.ts
@@ -169,7 +169,11 @@ export class Stencil extends View implements Graph.Plugin {
     } else {
       this.options.groups = groups
     }
-    groups.forEach((group) => this.initGroup(group))
+    groups.forEach((group) => {
+      this.initGroup(group)
+      const graph = this.graphs[group.name]
+      graph.on('cell:mousedown', this.onDragStart, this)
+    })
   }
 
   removeGroup(groupName: string | string[]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

bugfix: https://github.com/antvis/X6/issues/4007

### Motivation and Context

分组信息通常由服务端返回，那么会先调用stencil.addGroup, 再调用stencil.load来完成分组的显示, addGroup方法未监听mousedown事件,导致节点无法拖拽。

examples/x6-example-features 中补充了示例

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
