### PR TITLE
feat: selection's pointerEvents support function type

### DIFF
--- a/packages/x6-plugin-selection/src/selection.ts
+++ b/packages/x6-plugin-selection/src/selection.ts
@@ -126,7 +126,10 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
     const { ui, selection, translateBy, snapped } = options
 
     const allowTranslating =
-      (showNodeSelectionBox !== true || pointerEvents === 'none') &&
+      (showNodeSelectionBox !== true ||
+        (typeof pointerEvents === 'string'
+          ? pointerEvents
+          : pointerEvents?.(this.cells)) === 'none') &&
       !this.translating &&
       !selection
 
@@ -819,6 +822,7 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
 
         const className = this.boxClassName
         const box = document.createElement('div')
+        const pointerEvents = this.options.pointerEvents
         Dom.addClass(box, className)
         Dom.addClass(box, `${className}-${cell.isNode() ? 'node' : 'edge'}`)
         Dom.attr(box, 'data-cell-id', cell.id)
@@ -828,7 +832,11 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
           top: bbox.y,
           width: bbox.width,
           height: bbox.height,
-          pointerEvents: this.options.pointerEvents || 'auto',
+          pointerEvents: pointerEvents
+            ? typeof pointerEvents === 'string'
+              ? pointerEvents
+              : pointerEvents(this.cells)
+            : 'auto',
         })
         Dom.appendTo(box, this.container)
         this.showSelected()
@@ -978,7 +986,7 @@ export namespace SelectionImpl {
     rubberEdge?: boolean
 
     // Whether to respond event on the selectionBox
-    pointerEvents?: 'none' | 'auto'
+    pointerEvents?: 'none' | 'auto' | ((cells: Cell[]) => 'none' | 'auto')
 
     // with which mouse button the selection can be started
     eventTypes?: SelectionEventType[]

--- a/packages/x6-plugin-selection/src/selection.ts
+++ b/packages/x6-plugin-selection/src/selection.ts
@@ -126,10 +126,7 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
     const { ui, selection, translateBy, snapped } = options
 
     const allowTranslating =
-      (showNodeSelectionBox !== true ||
-        (typeof pointerEvents === 'string'
-          ? pointerEvents
-          : pointerEvents?.(this.cells)) === 'none') &&
+      (showNodeSelectionBox !== true || (pointerEvents && this.getPointerEventsValue(pointerEvents) === 'none')) &&
       !this.translating &&
       !selection
 
@@ -810,6 +807,12 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
     )
   }
 
+  protected getPointerEventsValue(pointerEvents: 'none' | 'auto' | ((cells: Cell[]) => 'none' | 'auto')) {
+    return typeof pointerEvents === 'string'
+      ? pointerEvents
+      : pointerEvents(this.cells)
+  }
+
   protected createSelectionBox(cell: Cell) {
     this.addCellSelectedClassName(cell)
 
@@ -833,9 +836,7 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
           width: bbox.width,
           height: bbox.height,
           pointerEvents: pointerEvents
-            ? typeof pointerEvents === 'string'
-              ? pointerEvents
-              : pointerEvents(this.cells)
+            ? this.getPointerEventsValue(pointerEvents)
             : 'auto',
         })
         Dom.appendTo(box, this.container)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### "pointerEvents",one of the plugin "Selection"'s configuation,supporting function type
see [#4062](https://github.com/antvis/X6/issues/4062)

<!--- Describe your changes in detail -->

### "pointerEvents",one of the plugin "Selection"'s configuation,supporting function type
see [#4062](https://github.com/antvis/X6/issues/4062)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
