### PR TITLE
fix: avoid access document or window in server side

### DIFF
--- a/packages/x6-common/src/dom/matrix.ts
+++ b/packages/x6-common/src/dom/matrix.ts
@@ -1,7 +1,6 @@
 import { PointLike } from '../types'
 import { createSvgElement } from './elem'
 
-const svgDocument = createSvgElement('svg') as SVGSVGElement
 const transformRegex = /(\w+)\(([^,)]+),?([^)]+)?\)/gi
 const transformSeparatorRegex = /[ ,]+/
 const transformationListRegex = /^(\w+)\((.*)\)/
@@ -36,6 +35,7 @@ export interface Scale {
  * @see https://developer.mozilla.org/en/docs/Web/API/SVGPoint
  */
 export function createSVGPoint(x: number, y: number) {
+  const svgDocument = createSvgElement('svg') as SVGSVGElement
   const p = svgDocument.createSVGPoint()
   p.x = x
   p.y = y
@@ -58,6 +58,7 @@ export function createSVGPoint(x: number, y: number) {
  * @see https://developer.mozilla.org/en/docs/Web/API/SVGMatrix
  */
 export function createSVGMatrix(matrix?: DOMMatrix | MatrixLike | null) {
+  const svgDocument = createSvgElement('svg') as SVGSVGElement
   const mat = svgDocument.createSVGMatrix()
   if (matrix != null) {
     const source = matrix as any
@@ -75,6 +76,7 @@ export function createSVGMatrix(matrix?: DOMMatrix | MatrixLike | null) {
  * @see https://developer.mozilla.org/en/docs/Web/API/SVGTransform
  */
 export function createSVGTransform(matrix?: DOMMatrix | MatrixLike) {
+  const svgDocument = createSvgElement('svg') as SVGSVGElement
   if (matrix != null) {
     if (!(matrix instanceof DOMMatrix)) {
       matrix = createSVGMatrix(matrix) // eslint-disable-line

--- a/packages/x6-common/src/dom/prefix.ts
+++ b/packages/x6-common/src/dom/prefix.ts
@@ -5,7 +5,7 @@ function camelize(str: string) {
 
 const memoized: { [key: string]: string | null } = {}
 const prefixes = ['webkit', 'ms', 'moz', 'o']
-const testStyle = document ? document.createElement('div').style : {}
+const testStyle = typeof document !== 'undefined' ? document.createElement('div').style : {}
 
 function getWithPrefix(name: string) {
   for (let i = 0; i < prefixes.length; i += 1) {

--- a/packages/x6-common/src/dom/selection.ts
+++ b/packages/x6-common/src/dom/selection.ts
@@ -1,4 +1,6 @@
 export const clearSelection = (function () {
+  if (typeof document == 'undefined')
+    return function () {}
   const doc = document as any
   if (doc.selection) {
     return function () {

--- a/packages/x6-common/src/dom/text.ts
+++ b/packages/x6-common/src/dom/text.ts
@@ -7,8 +7,6 @@ import { attr } from './attr'
 import { Vector } from '../vector'
 import { createSvgElement, empty } from './elem'
 
-const canvasContext = document.createElement('canvas').getContext('2d')!
-
 function createTextPathNode(
   attrs: { d?: string; 'xlink:href'?: string },
   elem: SVGElement,
@@ -374,6 +372,7 @@ export function text(
 }
 
 export function measureText(text: string, styles: any = {}) {
+  const canvasContext = document.createElement('canvas').getContext('2d')!
   if (!text) {
     return { width: 0 }
   }

--- a/packages/x6-common/src/polyfill/index.ts
+++ b/packages/x6-common/src/polyfill/index.ts
@@ -10,27 +10,29 @@ if (
 
 // compatible with ParentNode.append() before chrome 54
 // https://github.com/jserz/js_piece/blob/master/DOM/ParentNode/append()/append().md
-;(function (arr) {
-  arr.forEach((item) => {
-    if (Object.prototype.hasOwnProperty.call(item, 'append')) {
-      return
-    }
-    Object.defineProperty(item, 'append', {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value(...args: any[]) {
-        const docFrag = document.createDocumentFragment()
+if (typeof window !== 'undefined') {
+  ;(function (arr) {
+    arr.forEach((item) => {
+      if (Object.prototype.hasOwnProperty.call(item, 'append')) {
+        return
+      }
+      Object.defineProperty(item, 'append', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value(...args: any[]) {
+          const docFrag = document.createDocumentFragment()
 
-        args.forEach((arg: any) => {
-          const isNode = arg instanceof Node
-          docFrag.appendChild(
-            isNode ? arg : document.createTextNode(String(arg)),
-          )
-        })
+          args.forEach((arg: any) => {
+            const isNode = arg instanceof Node
+            docFrag.appendChild(
+              isNode ? arg : document.createTextNode(String(arg)),
+            )
+          })
 
-        this.appendChild(docFrag)
-      },
+          this.appendChild(docFrag)
+        },
+      })
     })
-  })
-})([Element.prototype, Document.prototype, DocumentFragment.prototype])
+  })([Element.prototype, Document.prototype, DocumentFragment.prototype])
+}

--- a/packages/x6/src/util/index.ts
+++ b/packages/x6/src/util/index.ts
@@ -10,8 +10,6 @@ import { Dom, PointData, PointLike } from '@antv/x6-common'
 import { normalize } from '../registry/marker/util'
 
 export namespace Util {
-  const svgDocument = Dom.createSvgElement('svg') as SVGSVGElement
-
   export const normalizeMarker = normalize
   /**
    * Transforms point by an SVG transformation represented by `matrix`.
@@ -47,6 +45,7 @@ export namespace Util {
     rect: Rectangle.RectangleLike,
     matrix: DOMMatrix,
   ) {
+    const svgDocument = Dom.createSvgElement('svg') as SVGSVGElement
     const p = svgDocument.createSVGPoint()
 
     p.x = rect.x


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

X6在多处module scope中直接访问了`document`、`window`等仅在client端可用的变量，导致一旦`import '@antv/X6'`服务端渲染就会出错（根据README，X6本应该支持服务端渲染）https://github.com/antvis/X6/blob/f2cae9637ebe1d3f1c26fe5209eae6e623e7c842/README.md?plain=1#L32

本PR将`document`等移至函数中，或加上条件保护，使代码在server端也能正常运行。

### Motivation and Context

fix #4095 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
