### PR TITLE
fix(plugin:export): it should have default value 'true' across it's doc.

### DIFF
--- a/packages/x6-plugin-export/src/index.ts
+++ b/packages/x6-plugin-export/src/index.ts
@@ -40,7 +40,13 @@ export class Export extends Basecoat<Export.EventArgs> implements Graph.Plugin {
     }, options)
   }
 
-  exportSVG(fileName = 'chart', options: Export.ToSVGOptions = {}) {
+  exportSVG(
+    fileName = 'chart',
+    options: Export.ToSVGOptions = {
+      copyStyles: true,
+      serializeImages: true,
+    },
+  ) {
     this.toSVG((svg: string) => {
       DataUri.downloadDataUri(DataUri.svgToDataUrl(svg), fileName)
     }, options)


### PR DESCRIPTION

### Description
  `@antv/x6-plugin-export`'s options table show that the default-value of `serializeImages` and `copyStyles`  is the `true`.However, the option argument has been set `{}` which will cause `serializeImages`  or `copyStyles` is `undefined` in runtime. the logical truth code won't be executed. 
![image](https://github.com/antvis/X6/assets/48853785/ba6346e1-7c0d-46b8-ac1d-79d9826bbe62)

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
