### PR TITLE
fix(plugin:export): it should have default value 'true' through doc

### DIFF
--- a/packages/x6-plugin-export/src/index.ts
+++ b/packages/x6-plugin-export/src/index.ts
@@ -49,6 +49,16 @@ export class Export extends Basecoat<Export.EventArgs> implements Graph.Plugin {
   toSVG(callback: Export.ToSVGCallback, options: Export.ToSVGOptions = {}) {
     this.notify('before:export', options)
 
+    // to keep pace with it's doc description witch, the default value should be true.
+    // without Object.hasOwn method cause by ts config target.
+    // without instance.hasOwnProperty method cause by ts rule.
+    // the condition will be false if these properties have been set undefined in the target,
+    // but will be true if these properties are not in the target, cause the doc.
+    !Object.prototype.hasOwnProperty.call(options, 'copyStyle') &&
+      (options.copyStyles = true)
+    !Object.prototype.hasOwnProperty.call(options, 'serializeImages') &&
+      (options.serializeImages = true)
+
     const rawSVG = this.view.svg
     const vSVG = Vector.create(rawSVG).clone()
     let clonedSVG = vSVG.node as SVGSVGElement

--- a/packages/x6-plugin-export/src/index.ts
+++ b/packages/x6-plugin-export/src/index.ts
@@ -104,7 +104,7 @@ export class Export extends Basecoat<Export.EventArgs> implements Graph.Plugin {
     //    custom stylesheets onto the `style` attribute of each of the nodes
     //    in SVG.
 
-    if (options.copyStyles !== false) {
+    if (options.copyStyles) {
       const document = rawSVG.ownerDocument!
       const raws = Array.from(rawSVG.querySelectorAll('*'))
       const clones = Array.from(clonedSVG.querySelectorAll('*'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
@antv/x6-plugin-export's options table show that the default-value of serializeImages and copyStyles is the true.However, the option argument has been set {} which will cause serializeImages or copyStyles is undefined in runtime. the logical truth code won't be executed.
<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
