### PR TITLE
fix: memory leak of graph view dispose(introduce by #4023)

### DIFF
--- a/packages/x6/src/graph/view.ts
+++ b/packages/x6/src/graph/view.ts
@@ -18,6 +18,11 @@ export class GraphView extends View {
 
   private restore: () => void
 
+  /** Graph's `this.container` is from outer, should not dispose */
+  protected get disposeContainer(): boolean {
+    return false
+  }
+
   protected get options() {
     return this.graph.options
   }

--- a/packages/x6/src/view/view.ts
+++ b/packages/x6/src/view/view.ts
@@ -13,6 +13,11 @@ export abstract class View<A extends EventArgs = any> extends Basecoat<A> {
     return 2
   }
 
+  /** If need remove `this.container` DOM */
+  protected get disposeContainer() {
+    return true
+  }
+
   constructor() {
     super()
     this.cid = Private.uniqueId()
@@ -39,8 +44,12 @@ export abstract class View<A extends EventArgs = any> extends Basecoat<A> {
       this.removeEventListeners(document)
       this.onRemove()
       delete View.views[this.cid]
+      if (this.disposeContainer) {
+        this.unmount(elem)
+      }
+    } else {
+      this.unmount(elem)
     }
-    this.unmount(elem)
     return this
   }
 
@@ -363,10 +372,10 @@ export abstract class View<A extends EventArgs = any> extends Basecoat<A> {
     return View.normalizeEvent(evt)
   }
 
-  // @View.dispose()
-  // dispose() {
-  //   this.remove()
-  // }
+  @View.dispose()
+  dispose() {
+    this.remove()
+  }
 }
 
 export namespace View {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

修复内存泄漏问题

最初的pr #4009 
因为没有考虑到 Graph View 的 container 需要保留, 在 #4023 中注释掉了 view 的清理逻辑, 导致会重新引发内存泄漏
现给view添加了清理时保留 container 的选项, 以实现兼容 Graph View 的历史逻辑

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
