### PR TITLE
fix: edge rendering correct label attrs

### DIFF
--- a/packages/x6/src/view/edge.ts
+++ b/packages/x6/src/view/edge.ts
@@ -406,7 +406,7 @@ export class EdgeView<
     this.cleanCache()
     this.updateConnection(options)
 
-    const attrs = this.cell.getAttrs()
+    const { text, ...attrs } = this.cell.getAttrs()
     if (attrs != null) {
       this.updateAttrs(this.container, attrs, {
         selectors: this.selectors,


### PR DESCRIPTION
edge的label渲染从labels中读取的配置，但是每次render的时候都会update 从attr的text中更新了每个label的属性，导致渲染错误，所以在update中将text单独取出去了