### PR TITLE
Angular Issues: view.js:59 Uncaught TypeError: Cannot set properties of undefined (setting 'innerHTML')

### DIFF
--- a/packages/x6-angular-shape/src/view.ts
+++ b/packages/x6-angular-shape/src/view.ts
@@ -44,9 +44,9 @@ export class AngularShapeView extends NodeView<AngularShape> {
   }
 
   protected renderAngularContent(): void {
-    this.unmountAngularContent()
     const container = this.getNodeContainer()
     if (container) {
+      this.unmountAngularContent()
       const node = this.cell
       const { injector, content } = registerInfo.get(node.shape)!
       const viewContainerRef = injector.get(ViewContainerRef)


### PR DESCRIPTION
In Angular you sometimes run into complete Flow Errors when Element was already unmounted and it tries to unmount it again

<!--- Provide a general summary of your changes in the Title above -->

### Description

Move the Unmount Function after the null check for the container to not kill the environment completly

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
