### PR TITLE
fix:  If the starting or ending point is the same as the intersection…

### DIFF
--- a/packages/x6/src/registry/connector/jumpover.ts
+++ b/packages/x6/src/registry/connector/jumpover.ts
@@ -68,6 +68,18 @@ function findLineIntersections(line: Line, crossCheckLines: Line[]) {
   crossCheckLines.forEach((crossCheckLine) => {
     const intersection = line.intersectsWithLine(crossCheckLine)
     if (intersection) {
+      const { x, y } = intersection;
+      const { start, end } = crossCheckLine;
+      const startIsIntersection =
+        Math.round(start.x) === Math.round(x) &&
+        Math.round(start.y) === Math.round(y);
+      const endIsIntersection =
+        Math.round(end.x) === Math.round(x) &&
+        Math.round(end.y) === Math.round(y);
+      //If the starting or ending point is the same as the intersection point, return
+      if (startIsIntersection || endIsIntersection) {
+        return;
+      }
       intersections.push(intersection)
     }
   })


### PR DESCRIPTION
… point, return

- fixed https://github.com/antvis/X6/issues/4042
- fixed https://github.com/antvis/X6/issues/3828

解决跳线异常问题

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
