### PR TITLE
fix: 浮点数精度丢失导致画布缩放卡死

### DIFF
--- a/packages/x6/src/graph/mousewheel.ts
+++ b/packages/x6/src/graph/mousewheel.ts
@@ -114,7 +114,6 @@ export class MouseWheel extends Base {
       let targetScale = this.graph.transform.clampScale(
         currentScale * this.cumulatedFactor,
       )
-      // console.log(targetScale, currentScale, this.cumulatedFactor)
 
       const minScale = this.widgetOptions.minScale || Number.MIN_SAFE_INTEGER
       const maxScale = this.widgetOptions.maxScale || Number.MAX_SAFE_INTEGER

--- a/packages/x6/src/graph/mousewheel.ts
+++ b/packages/x6/src/graph/mousewheel.ts
@@ -81,9 +81,9 @@ export class MouseWheel extends Base {
           // webkit and to avoid rounding errors for zoom steps
           this.cumulatedFactor =
             Math.round(this.currentScale * factor * 20) / 20 / this.currentScale
-          if (this.cumulatedFactor === 1) {
-            this.cumulatedFactor = 1.05
-          }
+        }
+        if (this.cumulatedFactor <= 1) {
+          this.cumulatedFactor = 1.05
         }
       } else {
         // zoomout
@@ -98,9 +98,9 @@ export class MouseWheel extends Base {
             Math.round(this.currentScale * (1 / factor) * 20) /
             20 /
             this.currentScale
-          if (this.cumulatedFactor === 1) {
-            this.cumulatedFactor = 0.95
-          }
+        }
+        if (this.cumulatedFactor >= 1) {
+          this.cumulatedFactor = 0.95
         }
       }
 
@@ -114,6 +114,8 @@ export class MouseWheel extends Base {
       let targetScale = this.graph.transform.clampScale(
         currentScale * this.cumulatedFactor,
       )
+      // console.log(targetScale, currentScale, this.cumulatedFactor)
+
       const minScale = this.widgetOptions.minScale || Number.MIN_SAFE_INTEGER
       const maxScale = this.widgetOptions.maxScale || Number.MAX_SAFE_INTEGER
       targetScale = NumberExt.clamp(targetScale, minScale, maxScale)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,7 +597,7 @@ importers:
         version: 1.0.0-rc.1(vue@3.2.47)
       vue-demi:
         specifier: latest
-        version: 0.14.6(@vue/composition-api@1.0.0-rc.1)(vue@3.2.47)
+        version: 0.14.8(@vue/composition-api@1.0.0-rc.1)(vue@3.2.47)
     devDependencies:
       '@antv/x6':
         specifier: ^2.x
@@ -46436,10 +46436,10 @@ packages:
     engines: { node: '>=0.10.0' }
     dev: false
 
-  /vue-demi@0.14.6(@vue/composition-api@1.0.0-rc.1)(vue@3.2.47):
+  /vue-demi@0.14.8(@vue/composition-api@1.0.0-rc.1)(vue@3.2.47):
     resolution:
       {
-        integrity: sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==,
+        integrity: sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==,
       }
     engines: { node: '>=12' }
     hasBin: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

在 `mousewheel` 计算下一个缩放尺寸时，会因为js浮点数计算问题导致缩放尺寸计算存在误差：
- 即在缩小画布时，会计算出增大画布的缩放比例；
- 在放大画布时，会计算出缩小画布的缩放比例

### Motivation and Context

在某些特定情况下，会导致画布的缩放比例被卡在某两个值之间来回切换，导致画布无法进行缩放。
<!--- If it fixes an open issue, please link to the issue here. -->
#4168 
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
