### PR TITLE
fix: react-shape this.selectors must valid

### DIFF
--- a/packages/x6-react-shape/src/view.ts
+++ b/packages/x6-react-shape/src/view.ts
@@ -18,9 +18,9 @@ export class ReactShapeView extends NodeView<ReactShape> {
   }
 
   getComponentContainer() {
-    return this.cell.prop('useForeignObject') === false
+    return this.selectors && (this.cell.prop('useForeignObject') === false
       ? (this.selectors.content as SVGElement)
-      : (this.selectors.foContent as HTMLDivElement)
+      : (this.selectors.foContent as HTMLDivElement));
   }
 
   confirmUpdate(flag: number) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

x6 v1版本在开启 async mode后 自定义注册的react节点 有概率出现如下报错
![image](https://github.com/user-attachments/assets/4f567550-1976-46f7-b005-8cc44249bcd0)

![image](https://github.com/user-attachments/assets/edcefd4c-6f39-4060-bbc9-39d0320a2c50)


<!--- Describe your changes in detail -->
v1需要对应 如下x6-react-shape v2 做空值校验
![image](https://github.com/user-attachments/assets/e25d6478-2a7f-426f-8e69-828f598df6ef)

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
