### PR TITLE
fix(x6-plugin-keyboard): triggerKey should use formatKey before call mousetrap

### DIFF
--- a/packages/x6-plugin-keyboard/src/keyboard.ts
+++ b/packages/x6-plugin-keyboard/src/keyboard.ts
@@ -80,7 +80,7 @@ export class KeyboardImpl extends Disposable implements IDisablable {
   }
 
   trigger(key: string, action?: KeyboardImpl.Action) {
-    this.mousetrap.trigger(key, action)
+    this.mousetrap.trigger(this.formatkey(key), action)
   }
 
   private focus(e: EventArgs['node:mouseup']) {


### PR DESCRIPTION
### Description

A bugfix of triggerKey function in x6-plugin-keyboard.

### Motivation and Context

X6 uses mousetrap as keyboard event listener, but the keys of keyboard are different between X6 and mousetrap. X6 uses a function called "formatKey" to translate X6 keyboard key to mousetrap keyboard key. For example: 'delete' in X6 will translate to 'del' in mousetrap.
  
But the triggerKey function didn't apply this formatKey function, this cound lead to some misunderstandings, developers may use triggerKey('delete'), but mousetrap accutally can't recognize what 'delete' is. That will look like a bug.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
