### PR TITLE
fix: enabling snapline plugin selecting and moving cells  bug

### DIFF
--- a/packages/x6-plugin-selection/src/selection.ts
+++ b/packages/x6-plugin-selection/src/selection.ts
@@ -573,7 +573,11 @@ export class SelectionImpl extends View<SelectionImpl.EventArgs> {
     if (otherOptions && otherOptions.translateBy) {
       const currentCell = this.graph.getCellById(otherOptions.translateBy)
       if (currentCell) {
-        map[currentCell.id] = true
+        // 问题：开启snapline后，当我们框选圆形组件、node2矩形组件（node2中有一个node3被embedding时）,translateby是node2时，导致node2和组合在一起的node3移动错乱，并且node1移动错误的bug
+        // 解决方法：
+        //      当我们在translateby == node2时，node3获取到位置改变事件后，需要触发node2的移动，，不应该将node2放到移动排除列表中，这样会导致node2不会移动。
+        //      我的改造方式是：注释掉代码map[currentCell.id] = true，在embedding时，父控件会跟随子控件位置发生改变
+
         currentCell.getDescendants({ deep: true }).forEach((child) => {
           map[child.id] = true
         })


### PR DESCRIPTION
…translateby是node2时，导致node2和组合在一起的node3移动错乱，并且node1移动错误的bug

<!--- Provide a general summary of your changes in the Title above -->

### Description
fix #4491
<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
