### PR TITLE
feat: after a node moved, auto offset when it overlaps with other nodes

### DIFF
--- a/packages/x6/src/graph/options.ts
+++ b/packages/x6/src/graph/options.ts
@@ -248,6 +248,11 @@ export namespace Options {
     restrict:
       | boolean
       | OptionItem<CellView | null, Rectangle.RectangleLike | number | null>
+    /**
+     * After a node is moved, if it overlaps with other nodes, it will be
+     * automatically offset (by default, no offset occurs).
+     */
+    autoOffset?: boolean
   }
 
   export interface Embedding {

--- a/sites/x6-sites/docs/api/graph/graph.en.md
+++ b/sites/x6-sites/docs/api/graph/graph.en.md
@@ -24,7 +24,7 @@ new Graph(options: Options)
 | [mousewheel](/en/docs/api/graph/mousewheel) | `boolean \| MouseWheel.Options` |  | Whether the mouse wheel can zoom, defaults to disabled. | `false` |
 | [grid](/en/docs/api/graph/grid) | `boolean \| number \| GridManager.Options` |  | The grid, defaults to a 10px grid but does not draw the grid background. | `false` |
 | [background](/en/docs/api/graph/background) | `false \| BackgroundManager.Options` |  | The background, defaults to not drawing the background. | `false` |
-| [translating](/en/docs/api/interacting/interaction#moving-range) | `Translating.Options` |  | Restricts node movement. | `{ restrict: false }` |
+| [translating](/en/docs/api/interacting/interaction#moving-range) | `Translating.Options` |  | Restricts node movement. After a node is moved, automatically offset when it overlaps with other nodes.  | `{ restrict: false， autoOffset: true }` |
 | [embedding](/en/docs/api/interacting/interaction#embedding) | `boolean \| Embedding.Options` |  | Whether to enable nested nodes, defaults to disabled. | `false` |
 | [connecting](/en/docs/api/interacting/interaction#connecting) | `Connecting.Options` |  | The connection options. | `{ snap: false, ... }` |
 | [highlighting](/en/docs/api/interacting/interaction#highlighting) | `Highlighting.Options` |  | The highlighting options. | `{...}` |

--- a/sites/x6-sites/docs/api/graph/graph.zh.md
+++ b/sites/x6-sites/docs/api/graph/graph.zh.md
@@ -24,7 +24,7 @@ new Graph(options: Options)
 | [mousewheel](/zh/docs/api/graph/mousewheel) | `boolean \| MouseWheel.Options` |  | 鼠标滚轮缩放，默认禁用。 | `false` |
 | [grid](/zh/docs/api/graph/grid) | `boolean \| number \| GridManager.Options` |  | 网格，默认使用 `10px` 的网格，但不绘制网格背景。 | `false` |
 | [background](/zh/docs/api/graph/background) | `false \| BackgroundManager.Options` |  | 背景，默认不绘制背景。 | `false` |
-| [translating](/zh/docs/api/interacting/interaction#移动范围) | `Translating.Options` |  | 限制节点移动。 | `{ restrict: false }` |
+| [translating](/zh/docs/api/interacting/interaction#移动范围) | `Translating.Options` |  | 限制节点移动、移动节点重叠时自动偏移。 | `{ restrict: false， autoOffset: true }` |
 | [embedding](/zh/docs/api/interacting/interaction#组合) | `boolean \| Embedding.Options` |  | 嵌套节点，默认禁用。 | `false` |
 | [connecting](/zh/docs/api/interacting/interaction#connecting) | `Connecting.Options` |  | 连线选项。 | `{ snap: false, ... }` |
 | [highlighting](/zh/docs/api/interacting/interaction#高亮) | `Highlighting.Options` |  | 高亮选项。 | `{...}` |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
After a node is moved, if it overlaps with other nodes, it will be automatically offset. The offset direction can also be specified (by default, no offset occurs).
![auto_offset](https://github.com/user-attachments/assets/0942269a-c49c-45e9-b607-01502bb2c7ba)

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
