### PR TITLE
test: add registry/background and registry/connection-point test cases

### DIFF
--- a/__tests__/registry/background/flip-x.spec.ts
+++ b/__tests__/registry/background/flip-x.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { flipX } from '../../../src/registry/background/flip-x'
+
+describe('flipX', () => {
+  it('应该正确翻转并拼接图片', () => {
+    // 创建模拟的上下文方法
+    const mockCtx = {
+      drawImage: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+    }
+
+    // 创建模拟的canvas对象
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(mockCtx),
+    }
+
+    // 替换全局document对象
+    vi.stubGlobal('document', {
+      createElement: vi.fn().mockReturnValue(mockCanvas),
+    })
+
+    // 模拟图片对象
+    const mockImage = {
+      width: 100,
+      height: 50,
+    }
+
+    // 执行测试
+    const result = flipX(mockImage as unknown as HTMLImageElement)
+
+    // 验证canvas创建和设置
+    expect(document.createElement).toHaveBeenCalledWith('canvas')
+    expect(mockCanvas.width).toBe(200)
+    expect(mockCanvas.height).toBe(50)
+
+    // 验证getContext调用
+    expect(mockCanvas.getContext).toHaveBeenCalledWith('2d')
+    // 验证绘图操作
+    expect(mockCtx.drawImage).toHaveBeenCalledTimes(2)
+    expect(mockCtx.drawImage).toHaveBeenNthCalledWith(
+      1,
+      mockImage,
+      0,
+      0,
+      100,
+      50,
+    )
+    expect(mockCtx.translate).toHaveBeenCalledWith(200, 0)
+    expect(mockCtx.scale).toHaveBeenCalledWith(-1, 1)
+    expect(mockCtx.drawImage).toHaveBeenNthCalledWith(
+      2,
+      mockImage,
+      0,
+      0,
+      100,
+      50,
+    )
+
+    // 验证返回值
+    expect(result).toBe(mockCanvas)
+
+    // 清理模拟
+    vi.unstubAllGlobals()
+  })
+})

--- a/__tests__/registry/background/flip-xy.spec.ts
+++ b/__tests__/registry/background/flip-xy.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import { flipXY } from '../../../src/registry/background/flip-xy'
+
+// 模拟 Image 对象
+class MockImage {
+  width = 100
+  height = 80
+  src = ''
+  onload?: () => void
+  constructor() {
+    setTimeout(() => this.onload?.(), 50)
+  }
+}
+
+// 模拟 Canvas 和 Context
+const mockCtx = {
+  drawImage: vi.fn(),
+  setTransform: vi.fn(),
+}
+
+const mockCanvas = {
+  width: 0,
+  height: 0,
+  getContext: vi.fn(() => mockCtx),
+}
+
+// 设置全局模拟
+vi.stubGlobal('document', {
+  createElement: vi.fn((tag) => {
+    if (tag === 'canvas') return mockCanvas
+    if (tag === 'img') return new MockImage()
+    return null
+  }),
+})
+
+describe('flipXY', () => {
+  beforeEach(() => {
+    // 重置所有模拟
+    vi.clearAllMocks()
+    mockCanvas.width = 0
+    mockCanvas.height = 0
+  })
+
+  it('应该创建一个 2x2 图像拼接的 canvas', () => {
+    const img = new MockImage()
+    const result = flipXY(img as unknown as HTMLImageElement)
+
+    expect(result).toBe(mockCanvas)
+    expect(mockCanvas.width).toBe(2 * img.width)
+    expect(mockCanvas.height).toBe(2 * img.height)
+  })
+
+  it('应该正确调用 drawImage 和 setTransform 进行图像翻转', () => {
+    const img = new MockImage()
+    flipXY(img as unknown as HTMLImageElement)
+
+    // 验证 getContext 调用
+    expect(mockCanvas.getContext).toHaveBeenCalledWith('2d')
+
+    // 验证四个象限的绘制
+    const calls = mockCtx.setTransform.mock.calls
+
+    // 第一个 transform 应该是 xy 翻转
+    expect(calls[0]).toEqual([
+      -1,
+      0,
+      0,
+      -1,
+      mockCanvas.width,
+      mockCanvas.height,
+    ])
+
+    // 第二个 transform 应该是 x 翻转
+    expect(calls[1]).toEqual([-1, 0, 0, 1, mockCanvas.width, 0])
+
+    // 第三个 transform 应该是 y 翻转
+    expect(calls[2]).toEqual([1, 0, 0, -1, 0, mockCanvas.height])
+
+    // 验证 drawImage 被调用了4次
+    expect(mockCtx.drawImage).toHaveBeenCalledTimes(4)
+    mockCtx.drawImage.mock.calls.forEach((call) => {
+      expect(call[0]).toBe(img)
+      expect(call[1]).toBe(0)
+      expect(call[2]).toBe(0)
+      expect(call[3]).toBe(img.width)
+      expect(call[4]).toBe(img.height)
+    })
+  })
+})

--- a/__tests__/registry/background/flip-xy.spec.ts
+++ b/__tests__/registry/background/flip-xy.spec.ts
@@ -7,9 +7,7 @@ class MockImage {
   height = 80
   src = ''
   onload?: () => void
-  constructor() {
-    setTimeout(() => this.onload?.(), 50)
-  }
+  constructor() {}
 }
 
 // 模拟 Canvas 和 Context

--- a/__tests__/registry/background/flip-y.spec.ts
+++ b/__tests__/registry/background/flip-y.spec.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flipY } from '../../../src/registry/background/flip-y'
+
+describe('flipY', () => {
+  // 保存原始 document
+  const originalDocument = globalThis.document
+
+  // 模拟 Image 对象
+  class MockImage {
+    width = 100
+    height = 50
+  }
+
+  // 模拟 canvas 上下文
+  const mockContext = {
+    drawImage: vi.fn(),
+    translate: vi.fn(),
+    scale: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+  }
+
+  // 模拟 canvas 元素
+  class MockCanvas {
+    width = 0
+    height = 0
+    getContext() {
+      return mockContext
+    }
+  }
+
+  beforeEach(() => {
+    // 完全实现 Document 接口的最小实现
+    globalThis.document = {
+      createElement(tagName: string) {
+        if (tagName === 'canvas') {
+          return new MockCanvas()
+        }
+        throw new Error(`Unsupported element: ${tagName}`)
+      },
+      // 必须实现 Document 的基本属性
+      documentElement: {},
+      head: {},
+      body: {},
+      // 类型断言确保满足 Document 接口
+    } as unknown as Document
+
+    // 重置所有 mock
+    vi.clearAllMocks()
+  })
+
+  afterAll(() => {
+    // 恢复原始 document
+    globalThis.document = originalDocument
+  })
+
+  it('应该创建一个高度翻倍的画布', () => {
+    const img = new MockImage()
+    const result = flipY(img as unknown as HTMLImageElement)
+
+    expect(result.width).toBe(img.width)
+    expect(result.height).toBe(img.height * 2)
+  })
+
+  it('应该在画布上绘制原始图像和翻转图像', () => {
+    const img = new MockImage()
+    flipY(img as unknown as HTMLImageElement)
+
+    expect(mockContext.drawImage).toHaveBeenCalledTimes(2)
+    expect(mockContext.drawImage).toHaveBeenNthCalledWith(
+      1,
+      img,
+      0,
+      0,
+      img.width,
+      img.height,
+    )
+    expect(mockContext.translate).toHaveBeenCalledWith(0, 2 * img.height)
+    expect(mockContext.scale).toHaveBeenCalledWith(1, -1)
+    expect(mockContext.drawImage).toHaveBeenNthCalledWith(
+      2,
+      img,
+      0,
+      0,
+      img.width,
+      img.height,
+    )
+  })
+
+  it('应该返回 canvas 元素', () => {
+    const img = new MockImage()
+    const result = flipY(img as unknown as HTMLImageElement)
+
+    expect(result).toBeInstanceOf(MockCanvas)
+  })
+})

--- a/__tests__/registry/background/watermark.spec.ts
+++ b/__tests__/registry/background/watermark.spec.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Angle } from '../../../src/geometry'
+import { watermark } from '../../../src/registry/background/watermark'
+
+// Mock HTMLCanvasElement 和 Image
+const mockDrawImage = vi.fn()
+const mockSetTransform = vi.fn()
+const mockRotate = vi.fn()
+const mockGetContext = vi.fn(() => ({
+  drawImage: mockDrawImage,
+  setTransform: mockSetTransform,
+  rotate: mockRotate,
+  resetTransform: vi.fn(),
+  clearRect: vi.fn(),
+}))
+
+// Mock document.createElement
+const mockCreateElement = vi.fn(() => ({
+  width: 0,
+  height: 0,
+  getContext: mockGetContext,
+}))
+
+// Mock Image constructor
+class MockImage {
+  width = 100
+  height = 50
+  constructor() {}
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('document', { createElement: mockCreateElement })
+  vi.stubGlobal('Image', MockImage as any)
+})
+
+describe('watermark', () => {
+  it('应该创建一个 3 倍大小的 canvas', () => {
+    const img = new Image()
+    const result = watermark(img, {})
+
+    expect(mockCreateElement).toHaveBeenCalledWith('canvas')
+    expect(result.width).toBe(img.width * 3)
+    expect(result.height).toBe(img.height * 3)
+  })
+
+  it('应该使用默认角度 -20 度', () => {
+    const img = new Image()
+    watermark(img, {})
+
+    // 验证旋转角度计算正确
+    const expectedRadians = Angle.toRad(-20)
+    expect(mockRotate).toHaveBeenCalledWith(expectedRadians)
+  })
+
+  it('应该使用自定义角度', () => {
+    const img = new Image()
+    const customAngle = 45
+    watermark(img, { angle: customAngle })
+
+    const expectedRadians = Angle.toRad(-customAngle)
+    expect(mockRotate).toHaveBeenCalledWith(expectedRadians)
+  })
+
+  it('应该在正确的位置绘制水印', () => {
+    const img = new Image()
+    watermark(img, {})
+    // 验证在 4x4 网格的特定位置绘制
+    // 应该调用 8 次 drawImage（因为 (i+j)%2 > 0 的条件）
+    expect(mockDrawImage).toHaveBeenCalledTimes(8)
+
+    // 验证每次调用的参数
+    for (let i = 0; i < 4; i++) {
+      for (let j = 0; j < 4; j++) {
+        if ((i + j) % 2 > 0) {
+          expect(mockSetTransform).toHaveBeenCalledWith(
+            1,
+            0,
+            0,
+            1,
+            (2 * i - 1) * ((img.width * 3) / 4),
+            (2 * j - 1) * ((img.height * 3) / 4),
+          )
+        }
+      }
+    }
+  })
+
+  it('应该返回 canvas 对象', () => {
+    const img = new Image()
+    const result = watermark(img, {})
+
+    expect(result).toBeDefined()
+    expect(result.getContext).toBeDefined()
+  })
+})
+
+describe('Angle utility', () => {
+  it('应该正确转换角度到弧度', () => {
+    expect(Angle.toRad(0)).toBe(0)
+    expect(Angle.toRad(180)).toBeCloseTo(Math.PI, 10)
+  })
+})

--- a/__tests__/registry/background/watermark.spec.ts
+++ b/__tests__/registry/background/watermark.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Angle } from '../../../src/geometry'
 import { watermark } from '../../../src/registry/background/watermark'
 
@@ -32,6 +32,10 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.stubGlobal('document', { createElement: mockCreateElement })
   vi.stubGlobal('Image', MockImage as any)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 describe('watermark', () => {

--- a/__tests__/registry/connection-point/anchor.spec.ts
+++ b/__tests__/registry/connection-point/anchor.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import { Line, Point } from '../../../src/geometry'
+import type { AnchorOptions } from '../../../src/registry/connection-point/anchor'
+import { anchor } from '../../../src/registry/connection-point/anchor'
+
+type Align = 'top' | 'right' | 'bottom' | 'left'
+
+function alignLine(line: Line, type: Align, offset = 0) {
+  const { start, end } = line
+  let a
+  let b
+  let direction
+  let coordinate: 'x' | 'y'
+
+  switch (type) {
+    case 'left':
+      coordinate = 'x'
+      a = end
+      b = start
+      direction = -1
+      break
+    case 'right':
+      coordinate = 'x'
+      a = start
+      b = end
+      direction = 1
+      break
+    case 'top':
+      coordinate = 'y'
+      a = end
+      b = start
+      direction = -1
+      break
+    case 'bottom':
+      coordinate = 'y'
+      a = start
+      b = end
+      direction = 1
+      break
+    default:
+      return
+  }
+
+  if (start[coordinate] < end[coordinate]) {
+    a[coordinate] = b[coordinate]
+  } else {
+    b[coordinate] = a[coordinate]
+  }
+
+  if (Number.isFinite(offset)) {
+    a[coordinate] += direction * offset
+    b[coordinate] += direction * offset
+  }
+}
+
+describe('anchor connection point', () => {
+  describe('alignLine', () => {
+    it('should align line to left', () => {
+      const line = new Line(new Point(10, 10), new Point(20, 30))
+      alignLine(line, 'left')
+
+      expect(line.start.x).toBe(10)
+      expect(line.start.y).toBe(10)
+      expect(line.end.x).toBe(10)
+      expect(line.end.y).toBe(30)
+    })
+
+    it('should align line to right', () => {
+      const line = new Line(new Point(10, 10), new Point(20, 30))
+      alignLine(line, 'right')
+
+      expect(line.start.x).toBe(20)
+      expect(line.start.y).toBe(10)
+      expect(line.end.x).toBe(20)
+      expect(line.end.y).toBe(30)
+    })
+
+    it('should align line to top', () => {
+      const line = new Line(new Point(10, 10), new Point(20, 30))
+      alignLine(line, 'top')
+
+      expect(line.start.x).toBe(10)
+      expect(line.start.y).toBe(10)
+      expect(line.end.x).toBe(20)
+      expect(line.end.y).toBe(10)
+    })
+
+    it('should align line to bottom', () => {
+      const line = new Line(new Point(10, 10), new Point(20, 30))
+      alignLine(line, 'bottom')
+
+      expect(line.start.x).toBe(10)
+      expect(line.start.y).toBe(30)
+      expect(line.end.x).toBe(20)
+      expect(line.end.y).toBe(30)
+    })
+
+    it('should apply offset when aligning', () => {
+      const line = new Line(new Point(10, 10), new Point(20, 30))
+      alignLine(line, 'left', 5)
+
+      expect(line.start.x).toBe(5)
+      expect(line.start.y).toBe(10)
+      expect(line.end.x).toBe(5)
+      expect(line.end.y).toBe(30)
+    })
+  })
+
+  describe('anchor function', () => {
+    const mockView = {} as any
+    const mockMagnet = {} as any
+
+    it('should return point without alignment', () => {
+      const line = new Line(new Point(0, 0), new Point(100, 100))
+      const options: AnchorOptions = { offset: 10 }
+
+      const result = anchor(line, mockView, mockMagnet, options)
+
+      expect(result).toBeInstanceOf(Point)
+      expect(result.x).toBeCloseTo(92.92893218813452, 1)
+      expect(result.y).toBeCloseTo(92.92893218813452, 1)
+    })
+
+    it('should align to left and apply offset', () => {
+      const line = new Line(new Point(50, 50), new Point(150, 150))
+      const options: AnchorOptions = {
+        align: 'left',
+        alignOffset: 5,
+        offset: 10,
+      }
+
+      const result = anchor(line, mockView, mockMagnet, options)
+
+      // 先对齐到左边，然后应用偏移
+      expect(result.x).toBeCloseTo(45, 1) // 对齐后的x坐标减去偏移
+      expect(result.y).toBeCloseTo(140, 1)
+    })
+
+    it('should align to right and apply offset', () => {
+      const line = new Line(new Point(50, 50), new Point(150, 150))
+      const options: AnchorOptions = {
+        align: 'right',
+        alignOffset: 5,
+        offset: 10,
+      }
+
+      const result = anchor(line, mockView, mockMagnet, options)
+
+      expect(result.x).toBeCloseTo(155, 1) // 对齐后的x坐标加上偏移
+      expect(result.y).toBeCloseTo(140, 1)
+    })
+
+    it('should handle zero offset', () => {
+      const line = new Line(new Point(0, 0), new Point(100, 100))
+      const options: AnchorOptions = { offset: 0 }
+
+      const result = anchor(line, mockView, mockMagnet, options)
+
+      expect(result).toBeInstanceOf(Point)
+      expect(result.equals(line.end)).toBe(true)
+    })
+
+    it('should handle undefined offset', () => {
+      const line = new Line(new Point(0, 0), new Point(100, 100))
+      const options: AnchorOptions = {}
+
+      const result = anchor(line, mockView, mockMagnet, options)
+
+      expect(result).toBeInstanceOf(Point)
+      expect(result.equals(line.end)).toBe(true)
+    })
+  })
+})

--- a/__tests__/registry/connection-point/bbox.spec.ts
+++ b/__tests__/registry/connection-point/bbox.spec.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { bbox } from '../../../src/registry/connection-point/bbox'
+import {
+  getStrokeWidth,
+  offset,
+} from '../../../src/registry/connection-point/util'
+
+// Mock util functions
+vi.mock('../../../src/registry/connection-point/util', () => ({
+  offset: vi.fn((p) => p),
+  getStrokeWidth: vi.fn(() => 0),
+}))
+
+describe('bbox connection point', () => {
+  const mockView = {
+    getBBoxOfElement: vi.fn(() => ({
+      inflate: vi.fn(),
+      intersect: vi.fn(),
+    })),
+  }
+
+  const mockMagnet = document.createElement('div')
+  const mockLine = {
+    start: { closest: vi.fn() },
+    end: { x: 100, y: 100 },
+    intersect: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return offset point when intersections exist', () => {
+    const intersections = [
+      { x: 50, y: 50 },
+      { x: 60, y: 60 },
+    ]
+    const closestPoint = { x: 50, y: 50 }
+
+    mockLine.intersect.mockReturnValue(intersections)
+    mockLine.start.closest.mockReturnValue(closestPoint)
+    mockView.getBBoxOfElement.mockReturnValue({
+      inflate: vi.fn(),
+      intersect: vi.fn(() => intersections),
+    })
+
+    const result = bbox(mockLine as any, mockView as any, mockMagnet, {})
+
+    expect(mockView.getBBoxOfElement).toHaveBeenCalledWith(mockMagnet)
+    expect(mockLine.intersect).toHaveBeenCalled()
+    expect(mockLine.start.closest).toHaveBeenCalledWith(intersections)
+    expect(offset).toHaveBeenCalledWith(closestPoint, mockLine.start, undefined)
+    expect(result).toBe(closestPoint)
+  })
+
+  it('should return line end when no intersections', () => {
+    mockLine.intersect.mockReturnValue(null)
+    mockView.getBBoxOfElement.mockReturnValue({
+      inflate: vi.fn(),
+      intersect: vi.fn(() => null),
+    })
+
+    const result = bbox(mockLine as any, mockView as any, mockMagnet, {})
+
+    expect(offset).toHaveBeenCalledWith(mockLine.end, mockLine.start, undefined)
+    expect(result).toBe(mockLine.end)
+  })
+
+  it('should inflate bbox when stroked option is true', () => {
+    const mockBBox = {
+      inflate: vi.fn(),
+      intersect: vi.fn(() => []),
+    }
+
+    mockView.getBBoxOfElement.mockReturnValue(mockBBox)
+    vi.mocked(getStrokeWidth).mockReturnValue(10)
+
+    bbox(mockLine as any, mockView as any, mockMagnet, { stroked: true })
+
+    expect(getStrokeWidth).toHaveBeenCalledWith(mockMagnet)
+    expect(mockBBox.inflate).toHaveBeenCalledWith(5) // 10 / 2
+  })
+
+  it('should not inflate bbox when stroked option is false', () => {
+    const mockBBox = {
+      inflate: vi.fn(),
+      intersect: vi.fn(() => []),
+    }
+
+    mockView.getBBoxOfElement.mockReturnValue(mockBBox)
+
+    bbox(mockLine as any, mockView as any, mockMagnet, { stroked: false })
+
+    expect(mockBBox.inflate).not.toHaveBeenCalled()
+  })
+
+  it('should pass offset options to offset function', () => {
+    const offsetOptions = { x: 10, y: 20 }
+
+    bbox(mockLine as any, mockView as any, mockMagnet, {
+      offset: offsetOptions,
+    })
+
+    expect(offset).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      offsetOptions,
+    )
+  })
+
+  it('should handle empty intersections array', () => {
+    mockLine.intersect.mockReturnValue([])
+    mockView.getBBoxOfElement.mockReturnValue({
+      inflate: vi.fn(),
+      intersect: vi.fn(() => []),
+    })
+
+    const result = bbox(mockLine as any, mockView as any, mockMagnet, {})
+
+    expect(offset).toHaveBeenCalledWith(mockLine.end, mockLine.start, undefined)
+    expect(result).toBe(mockLine.end)
+  })
+})

--- a/__tests__/registry/connection-point/rect.spec.ts
+++ b/__tests__/registry/connection-point/rect.spec.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FunctionExt } from '../../../src/common'
+import { Point } from '../../../src/geometry'
+import { bbox } from '../../../src/registry/connection-point/bbox'
+import { rect } from '../../../src/registry/connection-point/rect'
+import {
+  getStrokeWidth,
+  offset,
+} from '../../../src/registry/connection-point/util'
+
+// Mock 相关模块
+vi.mock('../../../src/common', () => ({
+  FunctionExt: {
+    call: vi.fn(),
+  },
+}))
+
+vi.mock('../../../src/registry/connection-point/bbox', () => ({
+  bbox: vi.fn(),
+}))
+
+vi.mock('../../../src/registry/connection-point/util', () => ({
+  getStrokeWidth: vi.fn(),
+  offset: vi.fn(),
+}))
+
+describe('rect connection point', () => {
+  let mockLine: any
+  let mockView: any
+  let mockMagnet: any
+  let mockOptions: any
+
+  beforeEach(() => {
+    // 重置所有 mock
+    vi.resetAllMocks()
+
+    // 创建 mock 对象
+    mockLine = {
+      clone: vi.fn(),
+      start: new Point(0, 0),
+      end: new Point(100, 100),
+    }
+
+    mockView = {
+      cell: {
+        isNode: vi.fn(),
+        getAngle: vi.fn(),
+      },
+      getUnrotatedBBoxOfElement: vi.fn(),
+    }
+
+    mockMagnet = document.createElement('div')
+    mockOptions = {
+      stroked: false,
+      offset: 0,
+    }
+
+    // 设置默认 mock 返回值
+    mockView.cell.isNode.mockReturnValue(true)
+    mockView.cell.getAngle.mockReturnValue(0)
+    mockView.getUnrotatedBBoxOfElement.mockReturnValue({
+      getCenter: vi.fn().mockReturnValue(new Point(50, 50)),
+      inflate: vi.fn(),
+    })
+  })
+
+  describe('when angle is 0', () => {
+    it('should call bbox function directly', () => {
+      const result = new Point(10, 10)
+      // 正确设置 FunctionExt.call 的返回值
+      const mockFunctionExtCall = FunctionExt.call as vi.Mock
+      mockFunctionExtCall.mockReturnValue(result)
+
+      const actual = rect.call(
+        {},
+        mockLine,
+        mockView,
+        mockMagnet,
+        mockOptions,
+        'source',
+      )
+
+      expect(mockView.cell.getAngle).toHaveBeenCalled()
+      expect(FunctionExt.call).toHaveBeenCalledWith(
+        bbox,
+        {},
+        mockLine,
+        mockView,
+        mockMagnet,
+        mockOptions,
+        'source',
+      )
+      expect(actual).toBe(result)
+    })
+  })
+
+  describe('when angle is not 0', () => {
+    let rotatedLine: any
+    let center: Point
+
+    beforeEach(() => {
+      mockView.cell.getAngle.mockReturnValue(45) // 设置角度不为0
+
+      center = new Point(50, 50)
+
+      // 创建完整的 rotatedLine 对象，包含所有必要的方法
+      rotatedLine = {
+        rotate: vi.fn(),
+        setLength: vi.fn(),
+        intersect: vi.fn(),
+        start: new Point(0, 0),
+        end: new Point(100, 100),
+      }
+
+      // 设置方法链式调用
+      rotatedLine.rotate.mockReturnValue(rotatedLine)
+      rotatedLine.setLength.mockReturnValue(rotatedLine)
+
+      // clone 返回 rotatedLine
+      mockLine.clone.mockReturnValue(rotatedLine)
+    })
+
+    it('should handle unrotated bbox calculation', () => {
+      const mockBbox = {
+        getCenter: vi.fn().mockReturnValue(center),
+        inflate: vi.fn(),
+      }
+      mockView.getUnrotatedBBoxOfElement.mockReturnValue(mockBbox)
+
+      const mockGetStrokeWidth = getStrokeWidth as vi.Mock
+      mockGetStrokeWidth.mockReturnValue(2)
+
+      rect.call(
+        {},
+        mockLine,
+        mockView,
+        mockMagnet,
+        { ...mockOptions, stroked: true },
+        'target',
+      )
+
+      expect(mockView.getUnrotatedBBoxOfElement).toHaveBeenCalledWith(
+        mockMagnet,
+      )
+      expect(mockGetStrokeWidth).toHaveBeenCalledWith(mockMagnet)
+      expect(mockBbox.inflate).toHaveBeenCalledWith(1)
+    })
+
+    it('should rotate line and find intersections', () => {
+      const mockBbox = {
+        getCenter: vi.fn().mockReturnValue(center),
+        inflate: vi.fn(),
+      }
+      mockView.getUnrotatedBBoxOfElement.mockReturnValue(mockBbox)
+
+      // 设置 intersect 返回值
+      rotatedLine.intersect.mockReturnValue([
+        new Point(25, 25),
+        new Point(75, 75),
+      ])
+
+      // 为 rotatedLine.start 添加 closest 方法
+      const closestPoint = new Point(25, 25)
+      rotatedLine.start.closest = vi.fn().mockReturnValue(closestPoint)
+
+      const expectedResult = new Point(20, 20)
+      const mockOffset = offset as vi.Mock
+      mockOffset.mockReturnValue(expectedResult)
+
+      const result = rect.call(
+        {},
+        mockLine,
+        mockView,
+        mockMagnet,
+        mockOptions,
+        'target',
+      )
+
+      // 验证方法调用
+      expect(mockLine.clone).toHaveBeenCalled()
+      expect(rotatedLine.rotate).toHaveBeenCalledWith(45, center)
+      expect(rotatedLine.setLength).toHaveBeenCalledWith(1e6)
+      expect(rotatedLine.intersect).toHaveBeenCalledWith(mockBbox)
+      expect(rotatedLine.start.closest).toHaveBeenCalledWith([
+        new Point(25, 25),
+        new Point(75, 75),
+      ])
+      expect(mockOffset).toHaveBeenCalledWith(
+        closestPoint.rotate(-45, center),
+        mockLine.start,
+        0,
+      )
+      expect(result).toBe(expectedResult)
+    })
+
+    it('should return line end when no intersections found', () => {
+      const mockBbox = {
+        getCenter: vi.fn().mockReturnValue(center),
+        inflate: vi.fn(),
+      }
+      mockView.getUnrotatedBBoxOfElement.mockReturnValue(mockBbox)
+
+      // 设置 intersect 返回 null
+      rotatedLine.intersect.mockReturnValue(null)
+
+      const expectedResult = new Point(30, 30)
+      const mockOffset = offset as vi.Mock
+      mockOffset.mockReturnValue(expectedResult)
+
+      const result = rect.call(
+        {},
+        mockLine,
+        mockView,
+        mockMagnet,
+        mockOptions,
+        'target',
+      )
+
+      expect(mockOffset).toHaveBeenCalledWith(mockLine.end, mockLine.start, 0)
+      expect(result).toBe(expectedResult)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle offset options', () => {
+      mockView.cell.getAngle.mockReturnValue(45)
+      const center = new Point(50, 50)
+      const mockBbox = {
+        getCenter: vi.fn().mockReturnValue(center),
+        inflate: vi.fn(),
+      }
+      mockView.getUnrotatedBBoxOfElement.mockReturnValue(mockBbox)
+
+      // 创建新的 rotatedLine 实例
+      const rotatedLine = {
+        rotate: vi.fn(),
+        setLength: vi.fn(),
+        intersect: vi.fn().mockReturnValue([new Point(25, 25)]),
+        start: new Point(0, 0),
+        end: new Point(100, 100),
+      }
+      rotatedLine.rotate.mockReturnValue(rotatedLine)
+      rotatedLine.setLength.mockReturnValue(rotatedLine)
+      rotatedLine.start.closest = vi.fn().mockReturnValue(new Point(25, 25))
+
+      mockLine.clone.mockReturnValue(rotatedLine)
+
+      const expectedResult = new Point(20, 20)
+      const mockOffset = offset as vi.Mock
+      mockOffset.mockReturnValue(expectedResult)
+
+      const result = rect.call(
+        {},
+        mockLine,
+        mockView,
+        mockMagnet,
+        { ...mockOptions, offset: 10 },
+        'target',
+      )
+
+      expect(mockOffset).toHaveBeenCalledWith(
+        expect.any(Point),
+        mockLine.start,
+        10,
+      )
+      expect(result).toBe(expectedResult)
+    })
+  })
+})

--- a/__tests__/registry/connection-point/util.spec.ts
+++ b/__tests__/registry/connection-point/util.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { Line, Point } from '../../../src/geometry'
+import {
+  findShapeNode,
+  getStrokeWidth,
+  offset,
+} from '../../../src/registry/connection-point/util'
+
+describe('connection-point util', () => {
+  describe('offset', () => {
+    it('should return p1 when offset is undefined', () => {
+      const p1 = new Point(10, 10)
+      const p2 = new Point(20, 20)
+      const result = offset(p1, p2)
+      expect(result).toEqual(p1)
+    })
+
+    it('should return p1 when offset is not finite number', () => {
+      const p1 = new Point(10, 10)
+      const p2 = new Point(20, 20)
+      const result = offset(p1, p2, NaN)
+      expect(result).toEqual(p1)
+    })
+
+    it('should apply numeric offset correctly', () => {
+      const p1 = new Point(10, 10)
+      const p2 = new Point(20, 20)
+      const result = offset(p1, p2, 5)
+
+      // 计算预期结果
+      const distance = p1.distance(p2)
+      const expected = p1.move(p2, -Math.min(5, distance - 1))
+      expect(result).toEqual(expected)
+    })
+
+    it('should apply object offset with y coordinate', () => {
+      const p1 = new Point(10, 10)
+      const p2 = new Point(20, 20)
+      const offsetObj = { x: 5, y: 3 }
+      const result = offset(p1, p2, offsetObj)
+
+      // 先计算平行线偏移
+      const line = new Line(p2, p1)
+      const parallelLine = line.parallel(offsetObj.y)
+      const expectedP1 = parallelLine.end
+      const expected = expectedP1.move(
+        parallelLine.start,
+        -Math.min(offsetObj.x, expectedP1.distance(parallelLine.start) - 1),
+      )
+
+      expect(result.x).toBeCloseTo(expected.x)
+      expect(result.y).toBeCloseTo(expected.y)
+    })
+
+    it('should handle zero offset', () => {
+      const p1 = new Point(10, 10)
+      const p2 = new Point(20, 20)
+      const result = offset(p1, p2, 0)
+      expect(result).toEqual(p1)
+    })
+  })
+
+  describe('getStrokeWidth', () => {
+    it('should return 0 when stroke-width attribute is null', () => {
+      const mockElement = {
+        getAttribute: () => null,
+      } as SVGElement
+
+      const result = getStrokeWidth(mockElement)
+      expect(result).toBe(0)
+    })
+
+    it('should return 0 when stroke-width is not a number', () => {
+      const mockElement = {
+        getAttribute: () => 'invalid',
+      } as SVGElement
+
+      const result = getStrokeWidth(mockElement)
+      expect(result).toBe(0)
+    })
+
+    it('should return parsed stroke width', () => {
+      const mockElement = {
+        getAttribute: () => '2.5',
+      } as SVGElement
+
+      const result = getStrokeWidth(mockElement)
+      expect(result).toBe(2.5)
+    })
+
+    it('should handle integer stroke width', () => {
+      const mockElement = {
+        getAttribute: () => '3',
+      } as SVGElement
+
+      const result = getStrokeWidth(mockElement)
+      expect(result).toBe(3)
+    })
+  })
+
+  describe('findShapeNode', () => {
+    it('should return null when magnet is null', () => {
+      const result = findShapeNode(null as any)
+      expect(result).toBeNull()
+    })
+
+    it('should return the node itself when it is not G or TITLE', () => {
+      const mockElement = {
+        tagName: 'RECT',
+      } as Element
+
+      const result = findShapeNode(mockElement)
+      expect(result).toBe(mockElement)
+    })
+
+    it('should skip G element and return its first child', () => {
+      const mockFirstChild = { tagName: 'RECT' } as Element
+      const mockElement = {
+        tagName: 'G',
+        firstElementChild: mockFirstChild,
+        nextElementSibling: null,
+      } as Element
+
+      const result = findShapeNode(mockElement)
+      expect(result).toBe(mockFirstChild)
+    })
+
+    it('should skip TITLE element and return its next sibling', () => {
+      const mockNextSibling = { tagName: 'CIRCLE' } as Element
+      const mockElement = {
+        tagName: 'TITLE',
+        firstElementChild: null,
+        nextElementSibling: mockNextSibling,
+      } as Element
+
+      const result = findShapeNode(mockElement)
+      expect(result).toBe(mockNextSibling)
+    })
+
+    it('should handle nested G elements', () => {
+      const mockFinalChild = { tagName: 'PATH' } as Element
+      const mockFirstChild = {
+        tagName: 'G',
+        firstElementChild: mockFinalChild,
+        nextElementSibling: null,
+      } as Element
+      const mockElement = {
+        tagName: 'G',
+        firstElementChild: mockFirstChild,
+        nextElementSibling: null,
+      } as Element
+
+      const result = findShapeNode(mockElement)
+      expect(result).toBe(mockFinalChild)
+    })
+
+    it('should return null when tagName is not a string', () => {
+      const mockElement = {
+        tagName: 123, // 非字符串
+      } as any
+
+      const result = findShapeNode(mockElement)
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<img width="1924" height="670" alt="image" src="https://github.com/user-attachments/assets/55691f81-d448-40e5-9a8e-bbf127b89a2d" />


<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [x] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
