### PR TITLE
feat: add multiple handles for segments

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -43,6 +43,7 @@ import { TransformExample } from './pages/transform'
 import { UndoExample } from './pages/undo'
 import { TransitionExample } from './pages/animation/transition'
 import { HistoryExample } from './pages/history'
+import { SegmentsExample } from './pages/edge/tool/segments'
 
 function App() {
   return (
@@ -64,6 +65,7 @@ function App() {
       <Route path="/router" element={<RouterExample />} />
       <Route path="/edge/tool/arrowhead" element={<ToolArrowheadExample />} />
       <Route path="/edge/tool/button" element={<ToolButtonExample />} />
+      <Route path="/edge/tool/segments" element={<SegmentsExample />} />
       <Route
         path="/edge/custom-connector"
         element={<CustomConnectorExample />}

--- a/examples/src/pages/edge/tool/segments.tsx
+++ b/examples/src/pages/edge/tool/segments.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Graph } from '@antv/x6'
+
+export class SegmentsExample extends React.Component {
+  private container = React.createRef<HTMLDivElement>()
+
+  componentDidMount() {
+    const graph = new Graph({
+      container: this.container.current,
+      width: 800,
+      height: 600,
+    })
+
+    const source = graph.addNode({
+      shape: 'rect',
+      position: { x: 60, y: 40 },
+      size: { width: 100, height: 60 },
+    })
+
+    const target = graph.addNode({
+      shape: 'rect',
+      position: { x: 650, y: 450 },
+      size: { width: 100, height: 60 },
+    })
+
+    graph.addEdge({
+      source,
+      target,
+      router: 'orth',
+      tools: [
+        {
+          name: 'segments',
+        },
+      ],
+      attrs: {
+        connection: {
+          stroke: '#333333',
+          strokeWidth: 3,
+        },
+      },
+    })
+  }
+
+  render() {
+    return (
+      <div className="x6-graph-wrap">
+        <div ref={this.container} className="x6-graph" />
+      </div>
+    )
+  }
+}

--- a/src/registry/tool/segments.ts
+++ b/src/registry/tool/segments.ts
@@ -45,11 +45,37 @@ export class Segments extends ToolItem<EdgeView, Options> {
     return this
   }
 
+  public getPoints() {
+    const edgeView = this.cellView
+    const points = edgeView.routePoints
+    if (points.length <= 2) return points
+
+    const result: Point[] = [points[0]]
+
+    for (let i = 1; i < points.length - 1; i++) {
+      const prev = result[result.length - 1]
+      const curr = points[i]
+      const next = points[i + 1]
+
+      const cross =
+        (curr.x - prev.x) * (next.y - prev.y) -
+        (curr.y - prev.y) * (next.x - prev.x)
+
+      if (cross !== 0) {
+        result.push(curr)
+      }
+    }
+
+    result.push(points[points.length - 1])
+
+    return result
+  }
+
   protected onRender() {
     Dom.addClass(this.container, this.prefixClassName('edge-tool-segments'))
     this.resetHandles()
     const edgeView = this.cellView
-    const vertices = [...this.vertices]
+    const vertices = [...this.getPoints()]
     vertices.unshift(edgeView.sourcePoint)
     vertices.push(edgeView.targetPoint)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

1. 新增 Segments 在未配置 vertices 时的多段 handle 支持

| before | after |
|----|----|
| ![1](https://github.com/user-attachments/assets/a661ca79-5878-498a-aa60-0d8084a627e2) | ![2](https://github.com/user-attachments/assets/4ce0a87e-16e1-42ad-a5a6-a5d7653a0111) |

```ts
graph.addEdge({
  source,
  target,
  router: 'orth',
  tools: [
    {
      name: 'segments',
    },
  ],
  attrs: {
    connection: {
      stroke: '#333333',
      strokeWidth: 3,
    },
  },
})
```

![123](https://github.com/user-attachments/assets/3bd9a108-0181-4eff-a8d9-e8c77111bfa4)
