### PR TITLE
feat: add plugin export example

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -44,6 +44,7 @@ import { UndoExample } from './pages/plugins/undo'
 import { TransitionExample } from './pages/animation/transition'
 import { HistoryExample } from './pages/history'
 import { SegmentsExample } from './pages/edge/tool/segments'
+import { ExportExample } from './pages/plugins/export'
 
 function App() {
   return (
@@ -99,6 +100,7 @@ function App() {
       <Route path="/plugins/stencil" element={<StencilExample />} />
       <Route path="/plugins/transform" element={<TransformExample />} />
       <Route path="/plugins/undo" element={<UndoExample />} />
+      <Route path="/plugins/export" element={<ExportExample />} />
 
       <Route path="/animation/transition" element={<TransitionExample />} />
       <Route path="/history" element={<HistoryExample />} />

--- a/examples/src/pages/index.tsx
+++ b/examples/src/pages/index.tsx
@@ -174,6 +174,10 @@ const dataSource = [
     example: 'plugins/undo',
     description: '撤销重做',
   },
+  {
+    example: 'plugins/export',
+    description: '导出',
+  },
   // ========= animation ========
   {
     example: 'animation/transition',

--- a/examples/src/pages/plugins/export/index.tsx
+++ b/examples/src/pages/plugins/export/index.tsx
@@ -1,0 +1,153 @@
+import '../../index.less'
+import { useRef, useEffect } from 'react'
+import { Button, Space, Divider } from 'antd'
+import { Graph, Export } from '@antv/x6'
+
+type ExportMethods = Pick<
+  Graph,
+  | 'exportSVG'
+  | 'exportPNG'
+  | 'exportJPEG'
+  | 'toSVG'
+  | 'toPNG'
+  | 'toJPEG'
+  | 'toSVGAsync'
+  | 'toPNGAsync'
+  | 'toJPEGAsync'
+>
+
+type SyncExportKeys = keyof Pick<
+  ExportMethods,
+  'exportSVG' | 'exportPNG' | 'exportJPEG'
+>
+
+type CallbackExportKeys = keyof Pick<
+  ExportMethods,
+  'toSVG' | 'toPNG' | 'toJPEG'
+>
+
+type AsyncExportKeys = keyof Pick<
+  ExportMethods,
+  'toSVGAsync' | 'toPNGAsync' | 'toJPEGAsync'
+>
+
+export const ExportExample = () => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const graphRef = useRef<Graph | undefined>(undefined)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const graph = new Graph({
+      container: containerRef.current,
+      width: 400,
+      height: 400,
+      grid: true,
+    })
+
+    const source = graph.addNode({
+      x: 50,
+      y: 150,
+      width: 80,
+      height: 40,
+      label: 'Hello',
+    })
+
+    const target = graph.addNode({
+      x: 280,
+      y: 250,
+      width: 80,
+      height: 40,
+      label: 'World',
+    })
+
+    graph.addEdge({
+      source,
+      target,
+    })
+
+    graph.use(new Export())
+
+    graphRef.current = graph
+
+    return () => {
+      graph.dispose()
+    }
+  }, [])
+
+  const handleSyncExport = (type: SyncExportKeys) => {
+    if (graphRef.current) {
+      const graph = graphRef.current
+      graph[type](`test ${type}`, {
+        preserveDimensions: true,
+      })
+    }
+  }
+
+  const handleCallbackExport = (type: CallbackExportKeys) => {
+    if (graphRef.current) {
+      const graph = graphRef.current
+      graph[type](
+        (dataUri) => {
+          // 1. toSVG  -> svgXML
+          // 2. toPNG  -> base64Image
+          // 3. toJPEG -> base64Image
+          console.log(`test ${type}`, dataUri)
+        },
+        {
+          preserveDimensions: true,
+        },
+      )
+    }
+  }
+
+  const handleAsyncExport = async (type: AsyncExportKeys) => {
+    if (graphRef.current) {
+      const graph = graphRef.current
+      const dataUri = await graph[type]({
+        preserveDimensions: true,
+      })
+      // 1. toSVGAsync  -> svgXML
+      // 2. toPNGAsync  -> base64Image
+      // 3. toJPEGAsync -> base64Image
+      console.log(`test ${type}`, dataUri)
+    }
+  }
+
+  return (
+    <div className="x6-graph-wrap">
+      <h1>export</h1>
+      <div ref={containerRef} className="x6-graph" />
+
+      <Space
+        style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}
+      >
+        {(['exportSVG', 'exportPNG', 'exportJPEG'] as SyncExportKeys[]).map(
+          (type) => (
+            <Button key={type} onClick={async () => handleSyncExport(type)}>
+              {type}
+            </Button>
+          ),
+        )}
+
+        <Divider type="vertical" />
+
+        {(['toSVG', 'toPNG', 'toJPEG'] as CallbackExportKeys[]).map((type) => (
+          <Button key={type} onClick={async () => handleCallbackExport(type)}>
+            {type}
+          </Button>
+        ))}
+
+        <Divider type="vertical" />
+
+        {(['toSVGAsync', 'toPNGAsync', 'toJPEGAsync'] as AsyncExportKeys[]).map(
+          (type) => (
+            <Button key={type} onClick={async () => handleAsyncExport(type)}>
+              {type}
+            </Button>
+          ),
+        )}
+      </Space>
+    </div>
+  )
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

add plugin export example

<img width="2940" height="1666" alt="image" src="https://github.com/user-attachments/assets/11ffd541-b13c-4e36-b575-71c28759bbf8" />


### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
