### PR TITLE
fix: extra offset may occur when reverse selecting in Selection plugin

### DIFF
--- a/src/plugin/selection/selection.ts
+++ b/src/plugin/selection/selection.ts
@@ -534,11 +534,9 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
         const dx = e.clientX - data.clientX + data.scrollerX
         const dy = e.clientY - data.clientY + data.scrollerY
 
-        const left = parseInt(Dom.css(this.container, 'left') || '0', 10)
-        const top = parseInt(Dom.css(this.container, 'top') || '0', 10)
         Dom.css(this.container, {
-          left: dx < 0 ? data.offsetX + dx : left,
-          top: dy < 0 ? data.offsetY + dy : top,
+          left: dx < 0 ? data.offsetX + dx : data.offsetX,
+          top: dy < 0 ? data.offsetY + dy : data.offsetY,
           width: Math.abs(dx),
           height: Math.abs(dy),
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
fixed: https://github.com/antvis/X6/issues/3874

修改后效果图：
![录屏2025-09-29 16 16 26](https://github.com/user-attachments/assets/6748c750-e116-4399-8066-4f8ab3a82f5d)

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
