### PR TITLE
feat: panning option default value set  to true

### DIFF
--- a/__tests__/plugin/__snapshots__/stencil-1.html
+++ b/__tests__/plugin/__snapshots__/stencil-1.html
@@ -19,7 +19,7 @@
           class="x6-widget-stencil-group-content"
         >
           <div
-            class="x6-graph"
+            class="x6-graph x6-graph-pannable"
             style="width: 200px; height: 800px;"
           >
             <div
@@ -141,7 +141,7 @@
           class="x6-widget-stencil-group-content"
         >
           <div
-            class="x6-graph"
+            class="x6-graph x6-graph-pannable"
             style="width: 200px; height: 800px;"
           >
             <div

--- a/__tests__/plugin/__snapshots__/stencil-2.html
+++ b/__tests__/plugin/__snapshots__/stencil-2.html
@@ -19,7 +19,7 @@
           class="x6-widget-stencil-group-content"
         >
           <div
-            class="x6-graph"
+            class="x6-graph x6-graph-pannable"
             style="width: 200px; height: 800px;"
           >
             <div
@@ -141,7 +141,7 @@
           class="x6-widget-stencil-group-content"
         >
           <div
-            class="x6-graph"
+            class="x6-graph x6-graph-pannable"
             style="width: 200px; height: 800px;"
           >
             <div

--- a/__tests__/plugin/__snapshots__/stencil-3.html
+++ b/__tests__/plugin/__snapshots__/stencil-3.html
@@ -19,7 +19,7 @@
           class="x6-widget-stencil-group-content"
         >
           <div
-            class="x6-graph"
+            class="x6-graph x6-graph-pannable"
             style="width: 200px; height: 800px;"
           >
             <div
@@ -106,7 +106,7 @@
           class="x6-widget-stencil-group-content"
         >
           <div
-            class="x6-graph"
+            class="x6-graph x6-graph-pannable"
             style="width: 200px; height: 800px;"
           >
             <div

--- a/__tests__/plugin/scroller.spec.ts
+++ b/__tests__/plugin/scroller.spec.ts
@@ -33,6 +33,7 @@ function createMockGraph() {
     container,
     view: { grid: document.createElement('div'), background: null },
     grid: { update: vi.fn(), draw: vi.fn(), clear: vi.fn() }, // ✅ mock grid
+    panning: { pannable: true },
     transform: {
       getScale: () => ({ sx: 1, sy: 1 }),
       resize: vi.fn(),

--- a/examples/src/pages/auto-resize/index.tsx
+++ b/examples/src/pages/auto-resize/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { SplitBox } from '@antv/x6-react-components'
+import React from 'react'
 import '@antv/x6-react-components/es/split-box/style/index.css'
 import { Graph, Scroller } from '@antv/x6'
 import '../index.less'

--- a/examples/src/pages/minimap/index.tsx
+++ b/examples/src/pages/minimap/index.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
-import { Radio } from 'antd'
 import { Graph, MiniMap, Scroller } from '@antv/x6'
+import { Radio } from 'antd'
+import * as React from 'react'
 import { SimpleNodeView } from './simple-view'
 import './index.less'
 
@@ -19,6 +19,7 @@ export default class Example extends React.Component {
       container: this.container,
       width: 600,
       height: 320,
+      panning: false,
       background: {
         color: '#F2F7FA',
       },

--- a/examples/src/pages/plugins/scroller/index.tsx
+++ b/examples/src/pages/plugins/scroller/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import { Export, Graph, MiniMap, Scroller, Selection } from '@antv/x6'
 import { Button } from 'antd'
-import { Graph, Export, Selection, MiniMap, Scroller } from '@antv/x6'
+import React from 'react'
 import '../../index.less'
 import './index.less'
 
@@ -23,6 +23,7 @@ export class ScrollerExample extends React.Component {
       grid: {
         visible: true,
       },
+      panning: false,
       mousewheel: {
         enabled: true,
         // fixed: false,

--- a/examples/src/pages/virtual-render/index.tsx
+++ b/examples/src/pages/virtual-render/index.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from 'react'
-import { Graph, Cell, Scroller } from '@antv/x6'
+import { type Cell, Graph, Scroller } from '@antv/x6'
+import type React from 'react'
+import { useEffect, useRef } from 'react'
 import '../index.less'
 import './index.less'
 
@@ -16,6 +17,7 @@ export const VirtualRenderExample: React.FC = () => {
       height: 800,
       grid: true,
       mousewheel: true,
+      panning: false,
       virtual: true,
     })
 

--- a/site/docs/api/graph/graph.zh.md
+++ b/site/docs/api/graph/graph.zh.md
@@ -20,7 +20,7 @@ new Graph(options: Options)
 | height | `number` |  | 画布高度，默认使用容器高度。 | - |
 | scaling | `{ min?: number, max?: number }` |  | 画布的最小最大缩放级别。 | `{ min: 0.01, max: 16 }` |
 | [autoResize](/tutorial/basic/graph#画布大小) | `boolean \| Element \| Document` |  | 是否监听容器大小改变，并自动更新画布大小。 | `false` |
-| [panning](/api/graph/panning) | `boolean \| PanningManager.Options` |  | 画布是否可以拖拽平移，默认禁用。 | `false` |
+| [panning](/api/graph/panning) | `boolean \| PanningManager.Options` |  | 画布是否可以拖拽平移，默认启用。 | `true` |
 | [mousewheel](/api/graph/mousewheel) | `boolean \| MouseWheel.Options` |  | 鼠标滚轮缩放，默认禁用。 | `false` |
 | [grid](/api/graph/grid) | `boolean \| number \| GridManager.Options` |  | 网格，默认使用 `10px` 的网格，但不绘制网格背景。 | `false` |
 | [background](/api/graph/background) | `false \| BackgroundManager.Options` |  | 背景，默认不绘制背景。 | `false` |

--- a/site/docs/api/graph/panning.zh.md
+++ b/site/docs/api/graph/panning.zh.md
@@ -16,12 +16,12 @@ redirect_from:
 普通画布(未使用 `scroller` 插件)通过开启 `panning` 选项来支持拖拽平移。
 
 :::warning{title=注意}
-不要同时使用 `scroller` 和 `panning`，因为两种形式在交互上有冲突。 
+不要同时使用 `scroller` 和 `panning`，因为两种形式在交互上有冲突。从 2.19.0 版本开始，`panning` 配置默认值为 `true` 。
 :::
 
 ```ts
 const graph = new Graph({
-  panning: true,
+  panning: true, // 不传该选项时，默认值也为 true
 })
 
 // 等同于

--- a/site/docs/tutorial/plugins/scroller.zh.md
+++ b/site/docs/tutorial/plugins/scroller.zh.md
@@ -14,7 +14,7 @@ redirect_from:
 :::
 
 :::warning{title=注意}
-当同时使用 `Scroller` 插件的时候请不要同时开启画布的 `panning` 配置，因为两种形式在交互上有冲突。 
+当同时使用 `Scroller` 插件的时候请不要同时开启画布的 `panning` 配置，因为两种形式在交互上有冲突。从 2.19.0 版本开始，`panning` 配置默认值为 `true` 。
 :::
 
 ## 使用
@@ -28,6 +28,7 @@ const graph = new Graph({
   background: {
     color: '#F2F7FA',
   },
+  panning: false,
 })
 graph.use(
   new Scroller({

--- a/site/src/tutorial/plugins/minimap/index.tsx
+++ b/site/src/tutorial/plugins/minimap/index.tsx
@@ -19,6 +19,7 @@ export default class Example extends React.Component {
       container: this.container,
       width: 600,
       height: 320,
+      panning: false,
       background: {
         color: '#F2F7FA',
       },

--- a/site/src/tutorial/plugins/scroller/index.tsx
+++ b/site/src/tutorial/plugins/scroller/index.tsx
@@ -72,6 +72,7 @@ export default class Example extends React.Component {
 
     const graph = new Graph({
       container: this.container,
+      panning: false,
       background: {
         color: '#F2F7FA',
       },

--- a/src/graph/options.ts
+++ b/src/graph/options.ts
@@ -1,5 +1,5 @@
-import { ObjectExt } from '../common'
 import type { Dom, Nilable } from '../common'
+import { ObjectExt } from '../common'
 import { Config } from '../config'
 import type { Rectangle } from '../geometry'
 import type { Graph } from '../graph'
@@ -417,7 +417,7 @@ export namespace Options {
     background: false,
 
     panning: {
-      enabled: false,
+      enabled: true,
       eventTypes: ['leftMouseDown'],
     },
     mousewheel: {

--- a/src/model/animation.ts
+++ b/src/model/animation.ts
@@ -1,5 +1,5 @@
-import { ObjectExt, KeyValue, Interp, Timing } from '../common'
-import { Cell } from './cell'
+import { Interp, type KeyValue, ObjectExt, Timing } from '../common'
+import type { Cell } from './cell'
 
 export class Animation {
   protected readonly ids: { [path: string]: number } = {}

--- a/src/plugin/minimap/index.ts
+++ b/src/plugin/minimap/index.ts
@@ -110,6 +110,7 @@ export class MiniMap extends View implements Graph.Plugin {
       grid: false,
       background: false,
       embedding: false,
+      panning: false,
     }
 
     this.targetGraph = this.options.createGraph

--- a/src/plugin/scroller/index.ts
+++ b/src/plugin/scroller/index.ts
@@ -387,6 +387,12 @@ export class Scroller
       this.updateClassName(true)
       this.scrollerImpl.startPanning(e)
       this.scrollerImpl.once('pan:stop', () => this.updateClassName(false))
+
+      if (this.graph.panning.pannable) {
+        console.warn(
+          'Detected that graph.panning and scroll panning are both enabled, which may cause unexpected behavior.',
+        )
+      }
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
feature: https://github.com/antvis/X6/issues/4831
### Description
实现后画布未开启配置也默认可拖动：
![录屏2025-10-20 17 56 11](https://github.com/user-attachments/assets/0bb00d04-e6f0-4c48-bc4c-b9f6b359475e)

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
