### PR TITLE
fix(edge): safari中marker标记不渲染的判断更新并增加针对safari兼容的test

### DIFF
--- a/src/view/edge/index.ts
+++ b/src/view/edge/index.ts
@@ -471,10 +471,10 @@ export class EdgeView<
 
     const { text, ...attrs } = this.cell.getAttrs()
     if (attrs != null) {
-      // FIXME: safari 兼容，重新渲染一次data-shape === 'edge' 的g元素，确保重排/重绘能渲染出marker
+      // FIXME: safari 兼容，重新渲染一次edge 的g元素，确保重排/重绘能渲染出marker
       if (
         this.container?.tagName === 'g' &&
-        this.container?.getAttribute?.('data-shape') === 'edge' &&
+        this.isEdgeElement(this.container) &&
         IS_SAFARI
       ) {
         const parent = this.container.parentNode


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- 请在上述标题中提供更改的概要 -->
issue: https://github.com/antvis/X6/issues/4834 的优化对应safari中是边的判断。并增加针对safari兼容的test

### 📝 Description
<!--- Describe your changes in detail -->
<!--- 详细描述你的改动 -->
原先针对data-shape === 'edge' 判断是否为边元素，发现data-shape其实可以自定义，不准确，发现内部已经有对应判断方法，使用已有判断方法。

### 🖼️ Screenshot
<!--- Comparison of screenshots before and after changes, it is best to be GIF -->
<!--- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌     | ✅    |
|<img width="2204" height="1312" alt="image" src="https://github.com/user-attachments/assets/bc28178f-ec9e-4218-a553-98b14b83f444" />|<img width="2204" height="1312" alt="image" src="https://github.com/user-attachments/assets/df531ae8-d20a-4426-9b61-31a0aa96878e" />|

### 💡 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- 为什么需要该更改？它解决了什么问题？ -->
safari中marker无法渲染，需要在update重新渲染一次edge元素，确保箭头正常展示。
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- 如果是修复已存在的 issue，请在此关联该 issue。 -->
https://github.com/antvis/X6/issues/4834
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->
<!--- 说明问题的修复方式；若是新特性，请列出最终的 API 实现和使用示例。 -->

### 🧩 Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- 你的改动属于哪些类型？在适用的选项上标记 `x`。 -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [x] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### 🔍 Self Check before Merge
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- 请逐项检查以下内容，并在适用项打上 `x`。 -->
<!--- Please add test case, docs, and demos -->
<!--- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
