### PR TITLE
fix(selection): prevent stale touch drag offset after blank click

### DIFF
--- a/__tests__/plugin/selection.spec.ts
+++ b/__tests__/plugin/selection.spec.ts
@@ -772,6 +772,53 @@ describe('Selection plugin', () => {
       expect(Number.parseFloat(box.style.width)).toBeCloseTo(bbox.width)
       expect(Number.parseFloat(box.style.height)).toBeCloseTo(bbox.height)
     })
+
+    it('should discard pending drag offset when blank touch click cleans selection', async () => {
+      replaceSelection({
+        rubberband: true,
+        multiple: true,
+        following: true,
+        showNodeSelectionBox: true,
+      })
+
+      const node = graph.addNode({
+        id: 'pending-drag-node',
+        x: 20,
+        y: 30,
+        width: 100,
+        height: 40,
+      })
+      selection.select(node)
+
+      const touchstart = new Event('touchstart', { bubbles: true })
+      Object.defineProperty(touchstart, 'changedTouches', {
+        value: [
+          {
+            identifier: 1,
+            target: graph.container,
+            clientX: 20,
+            clientY: 30,
+          },
+        ],
+      })
+      const down = new Dom.EventObject(touchstart)
+      Object.defineProperty(down, 'clientX', { configurable: true, value: 20 })
+      Object.defineProperty(down, 'clientY', { configurable: true, value: 30 })
+      selection['selectionImpl']['startTranslating'](down)
+      selection['selectionImpl']['updateSelectedNodesPosition']({
+        dx: 40,
+        dy: 20,
+      })
+
+      const click = new Dom.EventObject(new MouseEvent('click'))
+      graph.trigger('blank:click', { e: click })
+
+      await sleep(40)
+
+      expect(node.position()).toEqual({ x: 20, y: 30 })
+      expect(selection['selectionImpl']['dragPendingOffset']).toBe(null)
+      expect(graph.model.hasActiveBatch('move-selection')).toBe(false)
+    })
   })
 
   describe('onCellAdded', () => {

--- a/src/plugin/selection/selection.ts
+++ b/src/plugin/selection/selection.ts
@@ -394,6 +394,7 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
   }
 
   protected stopSelecting(evt: Dom.MouseUpEvent) {
+    const e = this.normalizeEvent(evt)
     // 重置拖拽状态和清理定时器
     this.isDragging = false
     this.boxesUpdated = false
@@ -403,21 +404,21 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
     }
 
     const graph = this.graph
-    const eventData = this.getEventData<CommonEventData>(evt)
+    const eventData = this.getEventData<CommonEventData>(e)
     const action = eventData.action
     switch (action) {
       case 'selecting': {
-        const client = graph.snapToGrid(evt.clientX, evt.clientY)
+        const client = graph.snapToGrid(e.clientX, e.clientY)
         const rect = this.getSelectingRect()
         const cells = this.getCellsInArea(rect)
         this.reset(cells, { batch: true })
         this.hideRubberband()
-        this.notifyBoxEvent('box:mouseup', evt, client.x, client.y, cells)
+        this.notifyBoxEvent('box:mouseup', e, client.x, client.y, cells)
         break
       }
 
       case 'translating': {
-        const client = graph.snapToGrid(evt.clientX, evt.clientY)
+        const client = graph.snapToGrid(e.clientX, e.clientY)
         if (this.dragPendingOffset) {
           const toApply = this.dragPendingOffset
           this.dragPendingOffset = null
@@ -438,7 +439,7 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
         // 清理本次拖拽缓存
         this.translatingCache = null
         this.draggingPreviewMode = 'translate'
-        this.notifyBoxEvent('box:mouseup', evt, client.x, client.y)
+        this.notifyBoxEvent('box:mouseup', e, client.x, client.y)
         this.repositionSelectionBoxesInPlace()
         break
       }
@@ -456,7 +457,7 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
     const e = this.normalizeEvent(evt)
     const eventData = this.getEventData<CommonEventData>(e)
     if (eventData) {
-      this.stopSelecting(evt)
+      this.stopSelecting(e)
     }
   }
 

--- a/src/plugin/selection/selection.ts
+++ b/src/plugin/selection/selection.ts
@@ -37,6 +37,7 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
   protected boxesUpdated: boolean
   protected updateThrottleTimer: ReturnType<typeof setTimeout> | null = null
   protected isDragging: boolean = false
+  protected isSelectionTranslating: boolean = false
   protected batchUpdating: boolean = false
   // 逐帧批处理拖拽位移，降低 translate 重绘频率
   protected dragRafId: number | null = null
@@ -310,12 +311,10 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
   }
 
   clean(options: SelectionImplSetOptions = {}) {
+    this.cancelSelectionTranslating()
     if (this.length) {
       this.unselect(this.cells, options)
     }
-    // 清理容器 transform 与位移累计
-    this.resetContainerPosition()
-    this.draggingPreviewMode = 'translate'
     return this
   }
 
@@ -435,7 +434,7 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
           this.movingRouterRestoreTimer = null
         }
         this.restoreMovingRouters()
-        this.graph.model.stopBatch('move-selection')
+        this.stopSelectionTranslatingBatch()
         // 清理本次拖拽缓存
         this.translatingCache = null
         this.draggingPreviewMode = 'translate'
@@ -526,7 +525,9 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
   }
 
   protected startTranslating(evt: Dom.MouseDownEvent) {
+    this.cancelSelectionTranslating()
     this.graph.model.startBatch('move-selection')
+    this.isSelectionTranslating = true
     const client = this.graph.snapToGrid(evt.clientX, evt.clientY)
     this.setEventData<TranslatingEventData>(evt, {
       action: 'translating',
@@ -537,6 +538,33 @@ export class SelectionImpl extends View<SelectionImplEventArgs> {
     })
     this.prepareTranslatingCache()
     this.draggingPreviewMode = this.getDraggingPreviewMode()
+  }
+
+  protected stopSelectionTranslatingBatch() {
+    if (this.isSelectionTranslating) {
+      this.graph.model.stopBatch('move-selection')
+      this.isSelectionTranslating = false
+    }
+  }
+
+  protected cancelSelectionTranslating() {
+    if (this.dragRafId != null) {
+      cancelAnimationFrame(this.dragRafId)
+      this.dragRafId = null
+    }
+    this.dragPendingOffset = null
+    this.isDragging = false
+    this.boxesUpdated = false
+    this.translatingCache = null
+    this.draggingPreviewMode = 'translate'
+    this.resetContainerPosition()
+
+    if (this.movingRouterRestoreTimer) {
+      clearTimeout(this.movingRouterRestoreTimer)
+      this.movingRouterRestoreTimer = null
+    }
+    this.restoreMovingRouters()
+    this.stopSelectionTranslatingBatch()
   }
 
   private getRestrictArea(): RectangleLike | null {


### PR DESCRIPTION
Cancel pending selection drag frame and offset when cleaning selection, so touch devices do not apply the previous drag offset again after blank click.

Closes #5070
### 📝 Description
当框选节点后进行拖拽，随后点击画布空白处时，可能会复用上一次尚未清理的拖拽偏移，导致节点再次发生位移。本次修复将 selection 拖拽状态的清理逻辑集中处理，在 clean() 时取消未执行的拖拽动画帧，清空残留的拖拽偏移和缓存状态，恢复拖拽过程中的路由降级状态，并关闭 selection 拖拽开启的 move-selection batch。

同时补充了 touch 清理路径的回归测试。

### 🖼️ Screenshot
<!--- Comparison of screenshots before and after changes, it is best to be GIF -->
<!--- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/6e3c934e-2a2b-4e99-aebb-c7415a38d10e   |   https://github.com/user-attachments/assets/794e689e-7250-466d-9c8e-318e4aeed4b6  |

### 💡 Motivation and Context
修复 https://github.com/antvis/X6/issues/5070。
  该问题只在触摸设备上更容易复现，原因是 touch 拖拽结束后可能仍保留上一轮 selection 拖拽的 pending offset。清理选区时主动丢弃这些残留状态，可以避免后续空白点击再次触发节点位移。
  本次改动不涉及公开 API 变化。

### 🧩 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [x] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### 🔍 Self Check before Merge
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- 请逐项检查以下内容，并在适用项打上 `x`。 -->
<!--- Please add test case, docs, and demos -->
<!--- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
