### PR TITLE
docs: fix typos in CONTRIBUTING and update http links to https

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ $ git checkout -b branch-name
 # Run the test after you finish your modification. Add new test cases or change old ones if you feel necessary
 $ npm test
 
-# If your modification pass the tests, congradulations it's time to push your work back to us. Notice that the commit message should be wirtten in the following format.
+# If your modification pass the tests, congratulations it's time to push your work back to us. Notice that the commit message should be written in the following format.
 $ git add . # git add -u to delete files
 $ git commit -m "fix(role): role.use must xxx"
 $ git push origin branch-name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ $ git checkout -b branch-name
 # Run the test after you finish your modification. Add new test cases or change old ones if you feel necessary
 $ npm test
 
-# If your modification pass the tests, congratulations it's time to push your work back to us. Notice that the commit message should be written in the following format.
+# If your modification passes the tests, congratulations! It's time to push your work back to us. Notice that the commit message should be written in the following format.
 $ git add . # git add -u to delete files
 $ git commit -m "fix(role): role.use must xxx"
 $ git push origin branch-name

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 </p>
 
 <p align="center">
-  <a href="http://x6.antv.antgroup.com/tutorial/about">Official Documentation</a> •
+  <a href="https://x6.antv.antgroup.com/tutorial/about">Official Documentation</a> •
   <a href="https://x6.antv.antgroup.com/tutorial/getting-started">Quick Start</a> •
-  <a href="http://x6.antv.antgroup.com/examples">Graph Examples</a> •
+  <a href="https://x6.antv.antgroup.com/examples">Graph Examples</a> •
   <a href="https://www.yuque.com/antv/x6/tox1ukbz5cw57qfy">FAQ</a> •
   <a href="https://codesandbox.io/s/mo-ban-55i8dp">Demo Template</a> •
   <a href="https://github.com/lloydzhou/awesome-x6">Awesome X6</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,9 +24,9 @@
 </p>
 
 <p align="center">
-  <a href="http://x6.antv.antgroup.com/tutorial/about">官网文档</a> •
+  <a href="https://x6.antv.antgroup.com/tutorial/about">官网文档</a> •
   <a href="https://x6.antv.antgroup.com/tutorial/getting-started">快速开始</a> •
-  <a href="http://x6.antv.antgroup.com/examples">图表示例</a> •
+  <a href="https://x6.antv.antgroup.com/examples">图表示例</a> •
   <a href="https://www.yuque.com/antv/x6/tox1ukbz5cw57qfy">常见问题</a> •
   <a href="https://codesandbox.io/s/mo-ban-55i8dp">Demo 模板</a> •
   <a href="https://github.com/lloydzhou/awesome-x6">Awesome X6</a>


### PR DESCRIPTION
## Summary

Fix two typos in CONTRIBUTING.md and update `http://` links to `https://` in README files.

### Changes

1. **CONTRIBUTING.md**: Fix spelling errors
   - `congradulations` → `congratulations`
   - `wirtten` → `written`

2. **README.md & README.zh-CN.md**: Update documentation links from `http://` to `https://`
   - `http://x6.antv.antgroup.com/tutorial/about` → `https://x6.antv.antgroup.com/tutorial/about`
   - `http://x6.antv.antgroup.com/examples` → `https://x6.antv.antgroup.com/examples`

The site at `x6.antv.antgroup.com` fully supports HTTPS, so these links should use the secure protocol.

### Test Plan

- Verify all updated links resolve correctly over HTTPS
- No code changes, documentation-only
